### PR TITLE
Looking up contact addresses

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -12,8 +12,9 @@
 namespace OCA\Maps\AppInfo;
 
 use OCP\AppFramework\App;
-
+use OCA\Maps\Service\AddressService;
 use OCP\Util;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 $app = new Application();
 $container = $app->getContainer();
@@ -23,6 +24,18 @@ $eventDispatcher->addListener('OCA\Files::loadAdditionalScripts', function() {
     Util::addScript('maps', 'filetypes');
     Util::addStyle('maps', 'filetypes');
 });
+
+// carddav/caldav lookup addresses
+$listener = function($event) use ($container) {
+    if ($event instanceof GenericEvent) {
+        $c = $event->getArgument('cardData');
+        $a = $container->query(AddressService::class);
+        $a->scheduleVCardForLookup($c);
+    }
+};
+
+$eventDispatcher->addListener('\OCA\DAV\CardDAV\CardDavBackend::createCard', $listener);
+$eventDispatcher->addListener('\OCA\DAV\CardDAV\CardDavBackend::updateCard', $listener);
 
 $l = \OC::$server->getL10N('maps');
 

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -13,6 +13,7 @@ namespace OCA\Maps\AppInfo;
 
 
 use OC\AppFramework\Utility\SimpleContainer;
+use OCA\Maps\Service\AddressService;
 use \OCP\AppFramework\App;
 use OCA\Maps\Controller\PageController;
 use OCA\Maps\Controller\UtilsController;
@@ -190,5 +191,6 @@ class Application extends App {
             }
         );
     }
+
 
 }

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
     <licence>agpl</licence>
     <author mail="eneiluj@posteo.net">Julien Veyssier</author>
     <author mail="kontakt+github@arne.email">Arne Hamann</author>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
     <namespace>Maps</namespace>
     <category>multimedia</category>
     <bugs>https://github.com/nextcloud/maps/issues</bugs>

--- a/lib/BackgroundJob/LookupMissingGeoJob.php
+++ b/lib/BackgroundJob/LookupMissingGeoJob.php
@@ -28,6 +28,8 @@ class LookupMissingGeoJob extends QueuedJob {
     /**
      * LookupMissingGeoJob constructor.
      *
+     * A QueuedJob to lookup missing geo information of addresses
+     *
      * @param AddressService $service
      * @param IJobList $jobList
      */
@@ -39,7 +41,9 @@ class LookupMissingGeoJob extends QueuedJob {
 
     public function run($arguments) {
         \OC::$server->getLogger()->debug("Cronjob maps address executed");
+        //lookup at most 200 addresses
         if (!$this->addressService->lookupMissingGeo(200)){
+            //if not all addresses where looked up successfully add a new job for next time
             $this->jobList->add(LookupMissingGeoJob::class,[]);
         }
     }

--- a/lib/BackgroundJob/LookupMissingGeoJob.php
+++ b/lib/BackgroundJob/LookupMissingGeoJob.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Nextcloud - maps
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Arne Hamann
+ * @copyright Arne Hamann 2019
+ */
+
+namespace OCA\Maps\BackgroundJob;
+
+use \OCA\Maps\Service\AddressService;
+use \OCP\BackgroundJob\QueuedJob;
+use \OCP\BackgroundJob\IJobList;
+use \OCP\AppFramework\Utility\ITimeFactory;
+
+class LookupMissingGeoJob extends QueuedJob {
+
+    /** @var AddressService */
+    private $addressService;
+
+    /** @var AddressService */
+    private $jobList;
+
+    /**
+     * LookupMissingGeoJob constructor.
+     *
+     * @param AddressService $service
+     * @param IJobList $jobList
+     */
+    public function __construct(ITimeFactory $timeFactory, AddressService $service, IJobList $jobList) {
+        parent::__construct($timeFactory);
+        $this->addressService = $service;
+        $this->jobList = $jobList;
+    }
+
+    public function run($arguments) {
+        \OC::$server->getLogger()->debug("Cronjob maps address executed");
+        if (!$this->addressService->lookupMissingGeo(200)){
+            $this->jobList->add(LookupMissingGeoJob::class,[]);
+        }
+    }
+}

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -17,24 +17,50 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\ILogger;
 use OCP\AppFramework\Controller;
 use OCP\Contacts\IManager;
+use OCA\Maps\Service\AddressService;
 
 class ContactsController extends Controller {
     private $userId;
     private $logger;
     private $contactsManager;
+    private $addressService;
 
-    public function __construct($AppName, ILogger $logger, IRequest $request, IManager $contactsManager, $UserId){
+    public function __construct($AppName, ILogger $logger, IRequest $request, IManager $contactsManager, AddressService $addressService, $UserId){
         parent::__construct($AppName, $request);
         $this->logger = $logger;
         $this->userId = $UserId;
         $this->contactsManager = $contactsManager;
+        $this->addressService = $addressService;
     }
 
     /**
      * @NoAdminRequired
      */
     public function getContacts() {
-        $result = $this->contactsManager->search('', ['GEO'], ['types'=>false]);
+        $contacts = $this->contactsManager->search('', ['FN'], ['types'=>false]);
+        $result = [];
+        $userid = trim($this->userId);
+        foreach ($contacts as $c) {
+            $uid = trim($c['UID']);
+            if (strcmp($c['URI'], 'Database:'.$c['UID'].'.vcf') !== 0 or
+                strcmp($uid, $userid) === 0
+            ) {
+                if(key_exists('GEO',$c)) {
+                    $geo = $c['GEO'];
+                } else {
+                    $geo = $this->addressService->addressToGeo($c["ADR"]);
+                }
+                if(strlen($geo)>1){
+                    array_push($result, [
+                        'FN'=>$c['FN'],
+                        'URI'=>$c['URI'],
+                        'UID'=>$c['UID'],
+                        'BOOKID'=>$c['addressbook-key'],
+                        'GEO'=>$geo
+                    ]);
+                }
+            }
+        }
         return new DataResponse($result);
     }
 

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -37,7 +37,7 @@ class ContactsController extends Controller {
      * @NoAdminRequired
      */
     public function getContacts() {
-        $contacts = $this->contactsManager->search('', ['FN'], ['types'=>false]);
+        $contacts = $this->contactsManager->search('', ['GEO','ADR'], ['types'=>false]);
         $result = [];
         $userid = trim($this->userId);
         foreach ($contacts as $c) {

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -34,6 +34,7 @@ class ContactsController extends Controller {
     }
 
     /**
+     * get contacts with coordinates
      * @NoAdminRequired
      */
     public function getContacts() {
@@ -45,6 +46,7 @@ class ContactsController extends Controller {
             if (strcmp($c['URI'], 'Database:'.$c['UID'].'.vcf') !== 0 or
                 strcmp($uid, $userid) === 0
             ) {
+                //If the contact has a geo attibute use this, otherwise try to get it from the address
                 if(key_exists('GEO',$c)) {
                     $geo = $c['GEO'];
                 } else {
@@ -65,6 +67,7 @@ class ContactsController extends Controller {
     }
 
     /**
+     * get all contacts
      * @NoAdminRequired
      */
     public function getAllContacts() {

--- a/lib/Migration/Version000009Date20190516000800.php
+++ b/lib/Migration/Version000009Date20190516000800.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Maps\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version000009Date20190516000800 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('maps_address_geo')) {
+			$table = $schema->createTable('maps_address_geo');
+			$table->addColumn('id', 'bigint', [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 41,
+			]);
+			$table->addColumn('adr', 'string', [
+				'notnull' => true,
+				'length' => 255,
+                'unique' => true,
+			]);
+			$table->addColumn('adr_norm', 'string', [
+				'notnull' => true,
+				'length' => 255,
+                'unique' => true,
+			]);
+			$table->addColumn('lat', 'float', [
+				'notnull' => false,
+				'length' => 10,
+			]);
+			$table->addColumn('lng', 'float', [
+				'notnull' => false,
+				'length' => 10,
+			]);
+            $table->addColumn('looked_up', 'boolean', [
+                'notnull' => true,
+            ]);
+			$table->addUniqueIndex(["adr", "adr_norm"]);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+}

--- a/lib/Service/AddressService.php
+++ b/lib/Service/AddressService.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Nextcloud - maps
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Arne Hamann
+ * @copyright Arne Hamann 2019
+ */
+
+namespace OCA\Maps\Service;
+
+use function OCA\Maps\Controller\remove_utf8_bom;
+use OCP\ILogger;
+use OCP\ICache;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Sabre\VObject\Reader;
+
+class AddressService {
+    private $qb;
+    private $dbconnection;
+    private $logger;
+
+    public function __construct(ICache $cache, ILogger $logger) {
+        $this->qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+        $this->dbconnection = \OC::$server->getDatabaseConnection();
+        $this->cache = $cache;
+        $this->logger = $logger;
+    }
+
+    //converts the address to geo lat;lon
+    public function addressToGeo($adr) {
+        $geo = $this->lookupAddress($adr);
+        return strval($geo[0]).";".strval($geo[1]);
+    }
+
+    /* Safely looks up an adr string
+     * First: Checks if the adress is knwon and in the db
+     *      Uses the this geo if it was looked up externally
+     *      Look's it up if it was not looked up
+     * @param $adr
+     * @return array($lat,$lng)
+     */
+    public function lookupAddress($adr){
+        $adr_norm = strtolower(preg_replace('/\s+/', '', $adr));
+        $this->qb->select("id","lat","lng","looked_up")
+            ->from("maps_address_geo")
+            ->where($this->qb->expr()->eq('adr_norm', $this->qb->createNamedParameter($adr_norm, IQueryBuilder::PARAM_STR)));
+        $req=$this->qb->execute();
+        $lat = null;
+        $lng = null;
+        $inDb = False;
+        while ($row = $req->fetch()) {
+            if ($row['looked_up']){
+                $id = $row['id'];
+                $lat = $row['lat'];
+                $lng = $row['lng'];
+                $lookedUp = False;
+                $inDb = True;
+            } else {
+                $id = $row['id'];
+                $geo = $this->lookupAddress($adr);
+                $lat = $geo[0];
+                $lng = $geo[1];
+                $lookedUp = $geo[3];
+                $inDb = True;
+            }
+            break;
+        }
+        $req->closeCursor();
+        $qb = $this->qb->resetQueryParts();
+        if (!$inDb) {
+            $foo = $this->scheduleForLookup($adr);
+            $id = $foo[0];
+            $lat = $foo[1];
+            $lng = $foo[2];
+
+        } else {
+            if ($lookedUp) {
+                $this->qb->update('maps_address_geo')
+                    ->set("lat", $qb->createNamedParameter($lat, IQueryBuilder::PARAM_STR))
+                    ->set("lng", $qb->createNamedParameter($lng, IQueryBuilder::PARAM_STR))
+                    ->set("looked_up", $qb->createNamedParameter($lookedUp, IQueryBuilder::PARAM_BOOL))
+                    ->where($this->qb->expr()->eq('id', $this->qb->createNamedParameter($id, IQueryBuilder::PARAM_STR)));
+            }
+        }
+
+        return [$lat, $lng];
+    }
+
+    //looks up the address on external provider returns lat, lon, lookupstate
+    private function unsafeLookupAddress($adr){
+        if (time() - ($this->cache->get("maps_address_last_lookup") ?? 0) > 1) {
+            $opts = array('http' =>
+                array(
+                    'method'  => 'GET',
+                    'user_agent' => "Nextcloud Maps app",
+                )
+            );
+            $context  = stream_context_create($opts);
+            $result=\json_decode(
+                file_get_contents(
+                    "https://nominatim.openstreetmap.org/search.php?q="
+                    .urlencode($adr)
+                    ."&format=json", False, $context
+                ),true);
+            $this->logger->debug("Externally looked up address: ".$adr." with result".print_r($result,true));
+            $foo=$this->cache->set("maps_address_last_lookup",time());
+            if(sizeof($result)>0){
+                if (key_exists("lat", $result[0]) AND
+                    key_exists("lon", $result[0])
+                ) {
+                    return [
+                        $result[0]["lat"],
+                        $result[0]["lon"], True
+                    ];
+                }
+            }
+            return [null, null, True];
+        }
+        return [null, null, False];
+    }
+
+    public function  scheduleVCardForLookup($cardData){
+        $vCard = Reader::read($cardData);
+        foreach ($vCard->children() as $property) {
+            if ($property->name === 'ADR') {
+                $adr = $property->getValue();
+                if ($adr !== ';;;;;;') {
+                    $this->lookupAddress($property->getValue());
+                }
+            }
+        }
+    }
+
+    //Schedules the address for an external lookup
+    private function scheduleForLookup($adr) {
+        $geo = $this->unsafeLookupAddress($adr);
+        $adr_norm = strtolower(preg_replace('/\s+/', '', $adr));
+        $this->qb->insert('maps_address_geo')
+            ->values([
+                'adr'=>$this->qb->createNamedParameter($adr,IQueryBuilder::PARAM_STR),
+                'adr_norm'=>$this->qb->createNamedParameter($adr_norm,IQueryBuilder::PARAM_STR),
+                'lat'=>$this->qb->createNamedParameter($geo[0],IQueryBuilder::PARAM_STR),
+                'lng'=>$this->qb->createNamedParameter($geo[1],IQueryBuilder::PARAM_STR),
+                'looked_up'=>$this->qb->createNamedParameter($geo[2],IQueryBuilder::PARAM_BOOL),
+            ]);
+        $req = $this->qb->execute();
+        $id = $this->qb->getLastInsertId();
+        $qb = $this->qb->resetQueryParts();
+        return [$id, $geo[0], $geo[1]];
+    }
+
+    //lookus up the geo information which have not been looked up
+    public function lookupMissingGeo(){
+
+    }
+}


### PR DESCRIPTION
This PR addresses #34 the part of the contacts address lookup.

We have the restriction that we're only allowed to lookup once a second on noamintim.  This is why the addresses are cached in the address_geo table.  

Lookup procedure to minimize request:

Address in db?
  - Yes
    - Looked up externally -> used cached $lat $lng
    - not Looked up externally -> try lookup Externally -> use that $lat lng
 - No
    - try to lookup externally -> add entry to database

On try lookup externally

- Last lookup older than 1 second -> lookup
- else -> return null, null


@eneiluj @jancborchardt any suggestions?