### PR TITLE
fix file hooks

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\App;
 use OCA\Maps\Service\AddressService;
 use OCP\Util;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OCA\Maps\Hooks\FileHooks;
 
 $app = new Application();
 $container = $app->getContainer();

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -23,7 +23,7 @@ use OCA\Maps\Controller\DevicesController;
 use OCA\Maps\Controller\DevicesApiController;
 use OCA\Maps\Controller\RoutingController;
 use OCA\Maps\Controller\TracksController;
-use OCA\Maps\Hook\FileHooks;
+use OCA\Maps\Hooks\FileHooks;
 use OCA\Maps\Service\PhotofilesService;
 use OCA\Maps\Service\FavoritesService;
 use OCA\Maps\Service\DevicesService;

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,4 +48,7 @@
             <route>maps.page.index</route>
         </navigation>
     </navigations>
+    <types>
+        <filesystem/>
+    </types>
 </info>

--- a/lib/Hooks/FileHooks.php
+++ b/lib/Hooks/FileHooks.php
@@ -10,7 +10,7 @@
  * @copyright Piotr Bator 2017
  */
 
-namespace OCA\Maps\Hook;
+namespace OCA\Maps\Hooks;
 
 use OC\Files\Filesystem;
 use OC\Files\View;


### PR DESCRIPTION
I had removed `<types>` in info.xml because the `occ app:check-code` complained about it and I didn't find anything in the doc. It appears that file hooks need that to work.

It's now working again.

I also moved FileHooks class to another namespace to make it like other apps and like advised in the doc.