### PR TITLE
run photo and track scan on app installation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,6 +35,11 @@
         <lib>exif</lib>
         <nextcloud min-version="15" max-version="17"/>
     </dependencies>
+    <repair-steps>
+        <install>
+            <step>OCA\Maps\Migration\InstallScan</step>
+        </install>
+    </repair-steps>
     <commands>
         <command>OCA\Maps\Command\RescanPhotos</command>
         <command>OCA\Maps\Command\RescanTracks</command>

--- a/js/script.js
+++ b/js/script.js
@@ -179,6 +179,14 @@
                 async: true
             }).done(function (response) {
                 optionsValues = response.values;
+
+                // check if install scan was done
+                if (!optionsValues.hasOwnProperty('installScanDone') || optionsValues.installScanDone !== 'yes') {
+                    OC.Notification.showTemporary(
+                        t('maps', 'Media scan was not done yet. Wait a few minutes/hours and reload this page to see your photos/tracks.')
+                    );
+                }
+
                 // set tilelayer before showing photo layer because it needs a max zoom value
                 if (optionsValues.hasOwnProperty('displaySlider') && optionsValues.displaySlider === 'true') {
                     $('#timeRangeSlider').show();

--- a/lib/BackgroundJob/LaunchUsersInstallScanJob.php
+++ b/lib/BackgroundJob/LaunchUsersInstallScanJob.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Nextcloud - maps
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier
+ * @copyright Julien Veyssier 2019
+ */
+
+namespace OCA\Maps\BackgroundJob;
+
+use \OCP\BackgroundJob\QueuedJob;
+use \OCP\BackgroundJob\IJobList;
+use \OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUser;
+
+use \OCA\Maps\BackgroundJob\UserInstallScanJob;
+
+class LaunchUsersInstallScanJob extends QueuedJob {
+
+    private $jobList;
+
+    /**
+     * LaunchUsersInstallScanJob constructor.
+     *
+     * A QueuedJob to launch a scan job for each user
+     *
+     * @param IJobList $jobList
+     */
+    public function __construct(ITimeFactory $timeFactory, IJobList $jobList, IUserManager $userManager) {
+        parent::__construct($timeFactory);
+        $this->jobList = $jobList;
+        $this->userManager = $userManager;
+    }
+
+    public function run($arguments) {
+        \OC::$server->getLogger()->debug('Launch users install scan jobs cronjob executed');
+        $this->userManager->callForSeenUsers(function (IUser $user) {
+            $this->jobList->add(UserInstallScanJob::class, ['userId' => $user->getUID()]);
+        });
+    }
+}

--- a/lib/BackgroundJob/UserInstallScanJob.php
+++ b/lib/BackgroundJob/UserInstallScanJob.php
@@ -16,6 +16,7 @@ use \OCP\BackgroundJob\QueuedJob;
 use \OCP\BackgroundJob\IJobList;
 use \OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IUserManager;
+use OCP\IConfig;
 
 use OCA\Maps\Service\PhotofilesService;
 use OCA\Maps\Service\TracksService;
@@ -33,9 +34,11 @@ class UserInstallScanJob extends QueuedJob {
      */
     public function __construct(ITimeFactory $timeFactory, IJobList $jobList,
                                 IUserManager $userManager,
+                                IConfig $config,
                                 PhotofilesService $photofilesService,
                                 TracksService $tracksService) {
         parent::__construct($timeFactory);
+        $this->config = $config;
         $this->jobList = $jobList;
         $this->userManager = $userManager;
         $this->photofilesService = $photofilesService;
@@ -48,6 +51,7 @@ class UserInstallScanJob extends QueuedJob {
         // scan photos and tracks for given user
         $this->rescanUserPhotos($userId);
         $this->rescanUserTracks($userId);
+        $this->config->setUserValue($userId, 'maps', 'installScanDone', 'yes');
     }
 
     private function rescanUserPhotos($userId) {

--- a/lib/BackgroundJob/UserInstallScanJob.php
+++ b/lib/BackgroundJob/UserInstallScanJob.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Nextcloud - maps
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Julien Veyssier
+ * @copyright Julien Veyssier 2019
+ */
+
+namespace OCA\Maps\BackgroundJob;
+
+use \OCP\BackgroundJob\QueuedJob;
+use \OCP\BackgroundJob\IJobList;
+use \OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+
+use OCA\Maps\Service\PhotofilesService;
+use OCA\Maps\Service\TracksService;
+
+class UserInstallScanJob extends QueuedJob {
+
+    private $jobList;
+
+    /**
+     * UserInstallScanJob constructor.
+     *
+     * A QueuedJob to scan user storage for photos and tracks
+     *
+     * @param IJobList $jobList
+     */
+    public function __construct(ITimeFactory $timeFactory, IJobList $jobList,
+                                IUserManager $userManager,
+                                PhotofilesService $photofilesService,
+                                TracksService $tracksService) {
+        parent::__construct($timeFactory);
+        $this->jobList = $jobList;
+        $this->userManager = $userManager;
+        $this->photofilesService = $photofilesService;
+        $this->tracksService = $tracksService;
+    }
+
+    public function run($arguments) {
+        $userId = $arguments['userId'];
+        \OC::$server->getLogger()->debug('Launch user install scan job for '.$userId.' cronjob executed');
+        // scan photos and tracks for given user
+        $this->rescanUserPhotos($userId);
+        $this->rescanUserTracks($userId);
+    }
+
+    private function rescanUserPhotos($userId) {
+        //$this->output->info('======== User '.$userId.' ========'."\n");
+        $c = 1;
+        foreach ($this->photofilesService->rescan($userId) as $path) {
+            //$this->output->info('['.$c.'] Photo "'.$path.'" added'."\n");
+            $c++;
+        }
+	}
+
+    private function rescanUserTracks($userId) {
+        //$this->output->info('======== User '.$userId.' ========'."\n");
+        $c = 1;
+        foreach ($this->tracksService->rescan($userId) as $path) {
+            //$this->output->info('['.$c.'] Track "'.$path.'" added'."\n");
+            $c++;
+        }
+    }
+
+}

--- a/lib/Migration/InstallScan.php
+++ b/lib/Migration/InstallScan.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Maps\Migration;
+
+use OCP\Encryption\IManager;
+use OCP\Files\NotFoundException;
+use OCP\IUser;
+use OCP\IUserManager;
+
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use OCP\Share;
+
+use OCA\Maps\Service\PhotofilesService;
+use OCA\Maps\Service\TracksService;
+
+/**
+ * Class InstallScan
+ *
+ * @package OCA\Maps\Migration
+ */
+class InstallScan implements IRepairStep {
+
+	/** @var IDBConnection */
+	private $connection;
+
+	/** @var  IConfig */
+	private $config;
+
+
+	public function __construct(IDBConnection $connection, IConfig $config,
+								IUserManager $userManager,
+								IManager $encryptionManager,
+								PhotofilesService $photofilesService,
+								TracksService $tracksService) {
+		$this->connection = $connection;
+		$this->config = $config;
+
+        $this->userManager = $userManager;
+        $this->encryptionManager = $encryptionManager;
+        $this->photofilesService = $photofilesService;
+        $this->tracksService = $tracksService;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 * @since 9.1.0
+	 */
+	public function getName() {
+		return 'Scan photos and tracks in users storages';
+	}
+
+	/**
+	 * @param IOutput $output
+	 */
+	public function run(IOutput $output) {
+		if (!$this->shouldRun()) {
+			return;
+		}
+
+        if ($this->encryptionManager->isEnabled()) {
+            $output->warning('Encryption is enabled. Installation photos/tracks scan aborted.');
+            return 1;
+        }
+		$this->output = $output;
+		// scan photos and tracks for all users
+		$this->userManager->callForSeenUsers(function (IUser $user) {
+			$this->rescanUserPhotos($user->getUID());
+		});
+		$this->userManager->callForSeenUsers(function (IUser $user) {
+			$this->rescanUserTracks($user->getUID());
+		});
+	}
+
+	protected function shouldRun() {
+		$appVersion = $this->config->getAppValue('maps', 'installed_version', '0.0.0');
+		return version_compare($appVersion, '0.0.10', '<');
+	}
+
+    private function rescanUserPhotos($userId) {
+        $this->output->info('======== User '.$userId.' ========'."\n");
+        $c = 1;
+        foreach ($this->photofilesService->rescan($userId) as $path) {
+            $this->output->info('['.$c.'] Photo "'.$path.'" added'."\n");
+            $c++;
+        }
+	}
+
+    private function rescanUserTracks($userId) {
+        $this->output->info('======== User '.$userId.' ========'."\n");
+        $c = 1;
+        foreach ($this->tracksService->rescan($userId) as $path) {
+            $this->output->info('['.$c.'] Track "'.$path.'" added'."\n");
+            $c++;
+        }
+    }
+
+}


### PR DESCRIPTION
We can run the scan with an install repair step. I've tested it on a fresh Nextcloud 16 install. I added a few photos and track files, then installed Maps app and it works :smile:.

Downside of this method, i guess an admin can think there is some kind of failure if the installation is too long.