### PR TITLE
attempt to fix "get contacts": 'foreach(->ADR...'

### DIFF
--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -87,28 +87,28 @@ class ContactsController extends Controller {
                 $card = $this->cdBackend->getContact($c['addressbook-key'], $c['URI']);
                 if ($card) {
                     $vcard = Reader::read($card['carddata']);
-                    //$adrs = $vcard->get('ADR');
-                    //error_log('NB '.count($vcard->ADR));
-                    foreach ($vcard->ADR as $adr) {
-                        $geo = $this->addressService->addressToGeo($adr->getValue(), $c['URI']);
-                        //var_dump($adr->parameters()['TYPE']->getValue());
-                        $adrtype = '';
-                        if (isset($adr->parameters()['TYPE'])) {
-                            $adrtype = $adr->parameters()['TYPE']->getValue();
-                        }
-                        if (strlen($geo) > 1) {
-                            array_push($result, [
-                                'FN'=>$c['FN'] ?? $this->N2FN($c['N']) ?? '???',
-                                'URI'=>$c['URI'],
-                                'UID'=>$c['UID'],
-                                'ADR'=>$adr->getValue(),
-                                'ADRTYPE'=>$adrtype,
-                                'HAS_PHOTO'=>(isset($c['PHOTO']) and $c['PHOTO'] !== null),
-                                'BOOKID'=>$c['addressbook-key'],
-                                'BOOKURI'=>$addressBookUri,
-                                'GEO'=>$geo,
-                                'GROUPS'=>$c['CATEGORIES'] ?? null
-                            ]);
+                    if (isset($vcard->ADR) and count($vcard->ADR) > 0) {
+                        foreach ($vcard->ADR as $adr) {
+                            $geo = $this->addressService->addressToGeo($adr->getValue(), $c['URI']);
+                            //var_dump($adr->parameters()['TYPE']->getValue());
+                            $adrtype = '';
+                            if (isset($adr->parameters()['TYPE'])) {
+                                $adrtype = $adr->parameters()['TYPE']->getValue();
+                            }
+                            if (strlen($geo) > 1) {
+                                array_push($result, [
+                                    'FN'=>$c['FN'] ?? $this->N2FN($c['N']) ?? '???',
+                                    'URI'=>$c['URI'],
+                                    'UID'=>$c['UID'],
+                                    'ADR'=>$adr->getValue(),
+                                    'ADRTYPE'=>$adrtype,
+                                    'HAS_PHOTO'=>(isset($c['PHOTO']) and $c['PHOTO'] !== null),
+                                    'BOOKID'=>$c['addressbook-key'],
+                                    'BOOKURI'=>$addressBookUri,
+                                    'GEO'=>$geo,
+                                    'GROUPS'=>$c['CATEGORIES'] ?? null
+                                ]);
+                            }
                         }
                     }
                 }

--- a/lib/Service/AddressService.php
+++ b/lib/Service/AddressService.php
@@ -161,8 +161,16 @@ class AddressService {
                 ]
             ];
             $context = stream_context_create($opts);
+
+            // we get rid of "post office box" field
+            $splitted_adr = explode(';', $adr);
+            if (count($splitted_adr) > 2) {
+                array_shift($splitted_adr);
+            }
+            $query_adr = implode(', ', $splitted_adr);
+
             $result_json = @file_get_contents(
-                'https://nominatim.openstreetmap.org/search.php?q='.urlencode($adr).'&format=json',
+                'https://nominatim.openstreetmap.org/search.php?q='.urlencode($query_adr).'&format=json',
                 false,
                 $context
             );


### PR DESCRIPTION
In reaction to the comment:

Nice new release, but there seems to be a bug in the contacts backend. If I try to load them I get the following message in my log files and the spinner goes on forever:
```
{"reqId":"XWhDd5NwMEnE5vBRUQgfxQAAAPc","level":0,"time":"2019-08-29T23:31:23+02:00","remoteAddr":"1.1.1.1","user":"user","app":"maps","method":"GET","url":"\/owncloud\/apps\/maps\/contacts","message":"Externally looked failed","userAgent":"Mozilla\/5.0 (X11; Linux x86_64; rv:68.0) Gecko\/20100101 Firefox\/68.0","version":"16.0.4.1"}

{"reqId":"XWhDd5NwMEnE5vBRUQgfxQAAAPc","level":3,"time":"2019-08-29T23:34:23+02:00","remoteAddr":"1.1.1.1","user":"user","app":"PHP","method":"GET","url":"\/owncloud\/apps\/maps\/contacts","message":"Invalid argument supplied for foreach() at \/var\/www\/owncloud\/apps\/maps\/lib\/Controller\/ContactsController.php#92","userAgent":"Mozilla\/5.0 (X11; Linux x86_64; rv:68.0) Gecko\/20100101 Firefox\/68.0","version":"16.0.4.1"}
```

@e-alfred Could you try this branch to check if the "foreach" error goes away?