### PR TITLE
refs #135 fix context menu routing actions

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1083,7 +1083,7 @@
         },
 
         contextRouteFrom: function(e) {
-            if (this.control) {
+            if (routingController.control) {
                 if (!routingController.enabled) {
                     routingController.toggleRouting();
                 }
@@ -1092,7 +1092,7 @@
         },
 
         contextRouteTo: function(e) {
-            if (this.control) {
+            if (routingController.control) {
                 if (!routingController.enabled) {
                     routingController.toggleRouting();
                 }
@@ -1101,7 +1101,7 @@
         },
 
         contextRoutePoint: function(e) {
-            if (this.control) {
+            if (routingController.control) {
                 if (!routingController.enabled) {
                     routingController.toggleRouting();
                 }


### PR DESCRIPTION
It was a big mistake. Context is different when calling function from map elements. `this` was referring to the map object and the code was written as if `this` was the routing controller.

I think it's fixed now.