### PR TITLE
refs #132 fix popup shift when avatar appears late

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -593,6 +593,8 @@ tr.selected td {
 .tooltip-contact-avatar {
     min-width: 70px;
     min-height: 70px;
+    max-width: 70px;
+    max-height: 70px;
     margin-left: 40px;
     margin-right: 40px;
     border-radius: 50%;

--- a/css/style.scss
+++ b/css/style.scss
@@ -591,7 +591,8 @@ tr.selected td {
 }
 
 .tooltip-contact-avatar {
-    width: 70px;
+    min-width: 70px;
+    min-height: 70px;
     margin-left: 40px;
     margin-right: 40px;
     border-radius: 50%;


### PR DESCRIPTION
It should solve the problem mentioned in #132 for all browsers. If the image size is set before it has been loaded, popup size does not change after having been displayed and the shift does not happen.