### PR TITLE
refs #102 warn user when importing favorite file with tracks/routes

### DIFF
--- a/js/favoritesController.js
+++ b/js/favoritesController.js
@@ -1146,7 +1146,7 @@ FavoritesController.prototype = {
             data: req,
             async: true
         }).done(function (response) {
-            OC.Notification.showTemporary(t('maps', '{nb} favorites imported from {path}', {nb: response, path: path}));
+            OC.Notification.showTemporary(t('maps', '{nb} favorites imported from {path}', {nb: response.nbImported, path: path}));
             var catToDel = [];
             for (var cat in that.categoryLayers) {
                 catToDel.push(cat);
@@ -1155,6 +1155,10 @@ FavoritesController.prototype = {
                 that.deleteCategoryMap(catToDel[i]);
             }
             that.getFavorites();
+            if (response.linesFound === true) {
+                OC.Notification.showTemporary(
+                    t('maps', 'Warning: tracks or routes were found in imported files, they were ignored.'));
+            }
         }).always(function (response) {
             $('#navigation-favorites').removeClass('icon-loading-small');
             $('.leaflet-container').css('cursor', 'grab');

--- a/lib/Controller/FavoritesController.php
+++ b/lib/Controller/FavoritesController.php
@@ -230,8 +230,8 @@ class FavoritesController extends Controller {
                 $file->isReadable()){
                 $lowerFileName = strtolower($file->getName());
                 if ($this->endswith($lowerFileName, '.gpx') or $this->endswith($lowerFileName, '.kml') or $this->endswith($lowerFileName, '.kmz')) {
-                    $nbImported = $this->favoritesService->importFavorites($this->userId, $file);
-                    return new DataResponse($nbImported);
+                    $result = $this->favoritesService->importFavorites($this->userId, $file);
+                    return new DataResponse($result);
                 }
                 else {
                     // invalid extension

--- a/tests/Unit/Controller/FavoritesControllerTest.php
+++ b/tests/Unit/Controller/FavoritesControllerTest.php
@@ -207,7 +207,7 @@ class FavoritesControllerTest extends \PHPUnit\Framework\TestCase {
         $status = $resp->getStatus();
         $this->assertEquals(200, $status);
         $data = $resp->getData();
-        $this->assertEquals(27, $data);
+        $this->assertEquals(27, $data['nbImported']);
 
         // get favorites
         $resp = $this->favoritesController->getFavorites();


### PR DESCRIPTION
Beginning to work on what's been said in #102.

There is now a warning message after having imported a gpx/kml/kmz file containing tracks/routes/linestring.