### PR TITLE
Fix Add Device Point error when optional value is empty string.

### DIFF
--- a/lib/Controller/DevicesApiController.php
+++ b/lib/Controller/DevicesApiController.php
@@ -113,10 +113,10 @@ class DevicesApiController extends ApiController {
      */
     public function addDevicePoint($apiversion, $lat, $lng, $timestamp=null, $user_agent=null, $altitude=null, $battery=null, $accuracy=null) {
         if (is_numeric($lat) and is_numeric($lng)) {
-            $timestamp = normalizeOptionalNumber($timestamp);
-            $altitude = normalizeOptionalNumber($altitude);
-            $battery = normalizeOptionalNumber($battery);
-            $accuracy = normalizeOptionalNumber($accuracy);
+            $timestamp = $this->normalizeOptionalNumber($timestamp);
+            $altitude = $this->normalizeOptionalNumber($altitude);
+            $battery = $this->normalizeOptionalNumber($battery);
+            $accuracy = $this->normalizeOptionalNumber($accuracy);
             $ts = $timestamp;
             if ($timestamp === null) {
                 $ts = (new \DateTime())->getTimestamp();

--- a/lib/Controller/DevicesApiController.php
+++ b/lib/Controller/DevicesApiController.php
@@ -113,6 +113,10 @@ class DevicesApiController extends ApiController {
      */
     public function addDevicePoint($apiversion, $lat, $lng, $timestamp=null, $user_agent=null, $altitude=null, $battery=null, $accuracy=null) {
         if (is_numeric($lat) and is_numeric($lng)) {
+            $timestamp = normalizeOptionalNumber($timestamp);
+            $altitude = normalizeOptionalNumber($altitude);
+            $battery = normalizeOptionalNumber($battery);
+            $accuracy = normalizeOptionalNumber($accuracy);
             $ts = $timestamp;
             if ($timestamp === null) {
                 $ts = (new \DateTime())->getTimestamp();
@@ -169,6 +173,13 @@ class DevicesApiController extends ApiController {
         else {
             return new DataResponse('no such device', 400);
         }
+    }
+
+    private function normalizeOptionalNumber($value) {
+        if (!is_numeric($value)) {
+            return null;
+        }
+        return $value;
     }
 
 }

--- a/tests/Unit/Controller/DevicesApiControllerTest.php
+++ b/tests/Unit/Controller/DevicesApiControllerTest.php
@@ -178,6 +178,14 @@ class DevicesApiControllerTest extends \PHPUnit\Framework\TestCase {
         }
         $this->assertEquals(true, $d2Found);
 
+        // This happens with a request such as /api/1.0/devices?lat=1.1&lng=2.2&timestamp=&user_agent=testDevice&altitude=&battery=&accuracy=
+        $resp = $this->devicesApiController->addDevicePoint('1.0', 1.1, 2.2, '', 'testDevice', '', '', '');
+        $status = $resp->getStatus();
+        $this->assertEquals(200, $status);
+        $data = $resp->getData();
+        $deviceId3 = $data['deviceId'];
+        $pointId3 = $data['pointId'];
+
         // test point values
         $resp = $this->devicesApiController->getDevicePoints($deviceId2);
         $status = $resp->getStatus();


### PR DESCRIPTION
This happens whith PhoneTrack App.

I found logs of it sending requests with query params as follows: `?lat=1.1&lng=2.2&timestamp=1111111111&user_agent=testDevice&altitude=&battery=95.0&accuracy=36.0`

In the above example the `altitude` is present with a value of empty string (""). This value was passed to the DB sevice, which would fail due to the value not being a number.

The fix just transforms any non-numeric values into null.