### PR TITLE
add Mapbox vector tiles support, not with self hosted servers FTM

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -545,7 +545,7 @@
                 }]
             });
             this.map.on('contextmenu', function(e) {
-                if ($(e.originalEvent.target).attr('id') === 'map') {
+                if ($(e.originalEvent.target).attr('id') === 'map' || $(e.originalEvent.target).hasClass('mapboxgl-map')) {
                     that.map.contextmenu.showAt(L.latLng(e.latlng.lat, e.latlng.lng));
                     that.map.clickpopup = true;
                 }
@@ -553,9 +553,8 @@
             this.map.clickpopup = null;
             this.map.leftClickLock = false;
             this.map.on('click', function(e) {
-                if ($(e.originalEvent.target).attr('id') === 'map') {
+                if ($(e.originalEvent.target).attr('id') === 'map' || $(e.originalEvent.target).hasClass('mapboxgl-map')) {
                     if (!that.map.leftClickLock && that.map.clickpopup === null) {
-                        console.log('no popup');
                         searchController.mapLeftClick(e);
                         that.map.clickpopup = true;
                     }

--- a/js/script.js
+++ b/js/script.js
@@ -640,6 +640,7 @@
                     onClick: function(btn, map) {
                         $('.leaflet-control-layers').toggle();
                         $('.easy-button-container').toggle();
+                        that.map.clickpopup = true;
                     }
                 }]
             });
@@ -732,6 +733,7 @@
             }
             $('.leaflet-control-layers').hide();
             $('.easy-button-container').show();
+            this.map.clickpopup = null;
         },
     };
 

--- a/js/script.js
+++ b/js/script.js
@@ -218,7 +218,7 @@
                         maxZoom: 22,
                         attribution: attrib
                     });
-                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox outdoors'], 'Mapbox outdoors');
+                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox outdoors'], 'Topographic');
 
                     mapController.baseLayers['Mapbox dark'] = L.mapboxGL({
                         accessToken: optionsValues.mapboxAPIKEY,
@@ -227,7 +227,7 @@
                         maxZoom: 22,
                         attribution: attrib
                     });
-                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox dark'], 'Mapbox dark');
+                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox dark'], 'Dark');
 
                     mapController.baseLayers['Mapbox satellite'] = L.mapboxGL({
                         accessToken: optionsValues.mapboxAPIKEY,
@@ -619,7 +619,7 @@
                 icon: 'fa fa-map-marker-alt',
                 iconLoading: 'fa fa-spinner fa-spin',
                 strings: {
-                    title: t('maps', 'See current location')
+                    title: t('maps', 'Current location')
                 },
                 flyTo: true,
                 returnToPrevBounds: true,
@@ -640,7 +640,7 @@
                 states: [{
                     stateName: 'no-importa',
                     icon:      '<a class="icon icon-menu" style="height: 100%"> </a>',
-                    title:     t('maps', 'Other layers'),
+                    title:     t('maps', 'Other maps'),
                     onClick: function(btn, map) {
                         $('.leaflet-control-layers').toggle();
                         $('.easy-button-container').toggle();
@@ -680,7 +680,7 @@
                 states: [{
                     stateName: 'no-importa',
                     icon:      '<img src="'+esriImageUrl+'"/>',
-                    title:     t('maps', 'Aerial map'),
+                    title:     t('maps', 'Satellite map'),
                     onClick: function(btn, map) {
                         that.changeTileLayer(that.defaultSatelliteLayer, true);
                     }
@@ -692,7 +692,7 @@
                 states: [{
                     stateName: 'no-importa',
                     icon:      '<img src="'+osmImageUrl+'"/>',
-                    title:     t('maps', 'Classic map'),
+                    title:     t('maps', 'Street map'),
                     onClick: function(btn, map) {
                         that.changeTileLayer(that.defaultStreetLayer, true);
                     }

--- a/js/script.js
+++ b/js/script.js
@@ -625,7 +625,11 @@
                 returnToPrevBounds: true,
                 setView: 'untilPan',
                 showCompass: true,
-                locateOptions: {enableHighAccuracy: true, maxZoom: 15}
+                locateOptions: {enableHighAccuracy: true, maxZoom: 15},
+                onLocationError: function(e) {
+                    optionsController.saveOptionValues({locControlEnabled: false});
+                    alert(e.message);
+                }
             }).addTo(this.map);
             $('.leaflet-control-locate a').click( function(e) {
                 optionsController.saveOptionValues({locControlEnabled: mapController.locControl._active});

--- a/js/script.js
+++ b/js/script.js
@@ -194,6 +194,50 @@
                     $('#timeRangeSlider').show();
                     $('#display-slider').prop('checked', true);
                 }
+
+                if (optionsValues.hasOwnProperty('mapboxAPIKEY') && optionsValues.mapboxAPIKEY !== '') {
+                    // add mapbox-gl tile server
+                    var attrib = '<a href="https://www.mapbox.com/about/maps/">© Mapbox</a> '+
+                        '<a href="https://www.openstreetmap.org/copyright">© OpenStreetMap</a> '+
+                        '<a href="https://www.mapbox.com/map-feedback/">'+t('maps', 'Improve this map')+'</a>';
+                    var attribSat = attrib + '<a href="https://www.digitalglobe.com/">© DigitalGlobe</a>'
+
+                    mapController.baseLayers['Mapbox vector streets'] = L.mapboxGL({
+                        accessToken: optionsValues.mapboxAPIKEY,
+                        style: 'mapbox://styles/mapbox/streets-v8',
+                        minZoom: 1,
+                        maxZoom: 22,
+                        attribution: attrib
+                    });
+                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox vector streets'], 'Mapbox vector streets');
+
+                    mapController.baseLayers['Mapbox vector outdoors'] = L.mapboxGL({
+                        accessToken: optionsValues.mapboxAPIKEY,
+                        style: 'mapbox://styles/mapbox/outdoors-v11',
+                        minZoom: 1,
+                        maxZoom: 22,
+                        attribution: attrib
+                    });
+                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox vector outdoors'], 'Mapbox vector outdoors');
+
+                    mapController.baseLayers['Mapbox vector bright'] = L.mapboxGL({
+                        accessToken: optionsValues.mapboxAPIKEY,
+                        style: 'mapbox://styles/mapbox/bright-v8',
+                        minZoom: 1,
+                        maxZoom: 22,
+                        attribution: attrib
+                    });
+                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox vector bright'], 'Mapbox vector bright');
+
+                    mapController.baseLayers['Mapbox satellite'] = L.mapboxGL({
+                        accessToken: optionsValues.mapboxAPIKEY,
+                        style: 'mapbox://styles/mapbox/satellite-v8',
+                        minZoom: 1,
+                        maxZoom: 22,
+                        attribution: attribSat
+                    });
+                    mapController.controlLayers.addBaseLayer(mapController.baseLayers['Mapbox satellite'], 'Mapbox satellite');
+                }
                 if (optionsValues.hasOwnProperty('tileLayer')) {
                     mapController.changeTileLayer(optionsValues.tileLayer);
                 }
@@ -642,6 +686,9 @@
             for (var ol in this.baseOverlays) {
                 this.map.removeLayer(this.baseOverlays[ol]);
             }
+            if (!this.baseLayers.hasOwnProperty(name)) {
+                name = 'OpenStreetMap';
+            }
             this.map.addLayer(this.baseLayers[name]);
             if (name === 'ESRI Aerial' || name === 'Watercolor') {
                 this.map.addLayer(this.baseOverlays['Roads and labels']);
@@ -839,7 +886,6 @@
                 this.addRouter('mapbox/walking', 'Mapbox by foot', null, optionsValues.mapboxAPIKEY);
                 this.addRouter('mapbox/driving-traffic', 'Mapbox by car with traffic', null, optionsValues.mapboxAPIKEY);
                 this.addRouter('mapbox/driving', 'Mapbox by car without traffic', null, optionsValues.mapboxAPIKEY);
-
             }
             if ((optionsValues.hasOwnProperty('graphhopperURL') && optionsValues.graphhopperURL !== '') ||
                 (optionsValues.hasOwnProperty('graphhopperAPIKEY') && optionsValues.graphhopperAPIKEY !== '') ){

--- a/js/script.js
+++ b/js/script.js
@@ -231,7 +231,7 @@
 
                     mapController.baseLayers['Mapbox satellite'] = L.mapboxGL({
                         accessToken: optionsValues.mapboxAPIKEY,
-                        style: 'mapbox://styles/mapbox/satellite-v8',
+                        style: 'mapbox://styles/mapbox/satellite-streets-v9',
                         minZoom: 1,
                         maxZoom: 22,
                         attribution: attribSat

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -54,6 +54,7 @@ class PageController extends Controller {
             // default routing engine
             $csp->addAllowedConnectDomain('https://*.project-osrm.org');
             $csp->addAllowedConnectDomain('https://api.mapbox.com');
+            $csp->addAllowedConnectDomain('https://events.mapbox.com');
             $csp->addAllowedConnectDomain('https://graphhopper.com');
             // allow connections to custom routing engines
             $urlKeys = [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "leaflet-mouse-position": "^1.0.4",
     "leaflet-contextmenu": "^1.4.0",
     "leaflet.elevation": "^0.0.3",
+    "mapbox-gl": "^1.4.1",
+    "mapbox-gl-leaflet": "^0.0.10",
     "d3": "^3.5.17",
     "nouislider": "^14.0.2",
     "ua-parser-js": "^0.7.20",

--- a/templates/content/index.php
+++ b/templates/content/index.php
@@ -28,6 +28,7 @@ style('maps', '../node_modules/leaflet-control-geocoder/dist/Control.Geocoder');
 style('maps', '../node_modules/leaflet-mouse-position/src/L.Control.MousePosition');
 style('maps', '../node_modules/leaflet-contextmenu/dist/leaflet.contextmenu.min');
 style('maps', '../node_modules/leaflet.elevation/dist/Leaflet.Elevation-0.0.2');
+style('maps', '../node_modules/mapbox-gl/dist/mapbox-gl');
 style('maps', 'fontawesome/css/all.min');
 script('maps', '../node_modules/leaflet/dist/leaflet');
 script('maps', '../node_modules/leaflet.markercluster/dist/leaflet.markercluster');
@@ -42,6 +43,8 @@ script('maps', '../node_modules/leaflet-mouse-position/src/L.Control.MousePositi
 script('maps', '../node_modules/leaflet-contextmenu/dist/leaflet.contextmenu.min');
 script('maps', '../node_modules/d3/d3.min');
 script('maps', '../node_modules/leaflet.elevation/dist/Leaflet.Elevation-0.0.2.min');
+script('maps', '../node_modules/mapbox-gl/dist/mapbox-gl');
+script('maps', '../node_modules/mapbox-gl-leaflet/leaflet-mapbox-gl');
 style('maps', 'style');
 ?>
 <div id="search">


### PR DESCRIPTION
Hey how,

`mapbox-gl-leaflet` has been added and Maps now automatically adds 4 tile servers if Mapbox API key is set:

* streets
* outdoors
* bright
* satellite

This PR targets 0.3 milestone but I think it can be included sooner.

This library can be used to create tile layers getting data from self-hosted OpenMapTiles servers! We "just" need to implement extra tile servers settings and yay!