### PR TITLE
Popups and tooltips fixes

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -634,6 +634,10 @@ tr.selected td {
     margin-top: 2px;
     margin-bottom: 2px;
 }
+.contactPopup .deleteContactAddress {
+    display: inline-block;
+    cursor: pointer;
+}
 
 .tooltip-contact-address-type {
     width: 100%;

--- a/css/style.scss
+++ b/css/style.scss
@@ -402,6 +402,10 @@ tr.selected td {
     width: 300px;
 }
 
+.leaflet-marker-contact-tooltip p {
+    margin-top: 2px;
+    margin-bottom: 2px;
+}
 .leaflet-marker-favorite-tooltip,
 .leaflet-marker-device-tooltip,
 .leaflet-marker-track-tooltip,
@@ -625,6 +629,10 @@ tr.selected td {
 }
 .contactPopup {
     width: 165px;
+}
+.contactPopup p {
+    margin-top: 2px;
+    margin-bottom: 2px;
 }
 
 .tooltip-contact-address-type {

--- a/js/contactsController.js
+++ b/js/contactsController.js
@@ -272,7 +272,7 @@ ContactsController.prototype = {
             marker.bindPopup(contactPopup, {
                 closeOnClick: true,
                 className: 'popovermenu open popupMarker contactPopup',
-                offset: L.point(-5, -19)
+                offset: L.point(-5, 5)
             });
             marker.openPopup();
             this._map.clickpopup = true;
@@ -502,7 +502,7 @@ ContactsController.prototype = {
                 permanent: true,
                 className: 'leaflet-marker-contact-tooltip',
                 direction: 'top',
-                offset: L.point(0, -25)
+                offset: L.point(0, 0)
             });
         }
     },

--- a/js/favoritesController.js
+++ b/js/favoritesController.js
@@ -847,6 +847,7 @@ FavoritesController.prototype = {
             source: catList
         });
         $('input[role="name"]').focus().select();
+        this.map.clickpopup = true;
     },
 
     getFavoritePopupContent: function(fav) {
@@ -902,12 +903,15 @@ FavoritesController.prototype = {
 
         e.target.unbindPopup();
         var popupContent = this._map.favoritesController.getFavoriteContextPopupContent(fav);
-        e.target.bindPopup(popupContent, {
+
+        var popup = L.popup({
             closeOnClick: true,
             className: 'popovermenu open popupMarker',
             offset: L.point(-5, 9)
-        });
-        e.target.openPopup();
+        })
+            .setLatLng([fav.lat, fav.lng])
+            .setContent(popupContent)
+            .openOn(this._map);
     },
 
     getFavoriteContextPopupContent: function(fav) {


### PR DESCRIPTION
A few changes around popups and tooltips:

* fix left click on map when favorite edition popup is there
* fix favorite right click popup that was replacing edition popup after being showed once
* show contact popup and tooltip at the exact same position than the marker (replacement effect)
* make contact tooltip and popup look the same
* add 'delete this address' button in contact popup