### PR TITLE
refs #169 don't get contacts from disabled address books

### DIFF
--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -58,7 +58,20 @@ class ContactsController extends Controller {
         $addressBooks = $this->contactsManager->getUserAddressBooks();
         $result = [];
         $userid = trim($this->userId);
+        // get addressbook ids
+        $bookids = [];
         foreach ($contacts as $c) {
+            if (!in_array($c['addressbook-key'], $bookids)) {
+                array_push($bookids, $c['addressbook-key']);
+            }
+        }
+        // determine if addressbooks are enabled
+        $bookIsEnabled = $this->getBookIsEnabled($bookids);
+
+        foreach ($contacts as $c) {
+            if (!$bookIsEnabled[$c['addressbook-key']]) {
+                continue;
+            }
             $addressBookUri = $addressBooks[$c['addressbook-key']]->getUri();
             $uid = trim($c['UID']);
             // we don't give users, just contacts
@@ -117,6 +130,44 @@ class ContactsController extends Controller {
         return new DataResponse($result);
     }
 
+    private function getBookIsEnabled($bookids) {
+        $bookIsEnabled = [];
+        $qb = $this->qb;
+        foreach ($bookids as $bookid) {
+            // first get the address book uri in oc_addressbooks
+            $qb->select('uri', 'principaluri')
+                ->from('addressbooks')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($bookid, IQueryBuilder::PARAM_INT)));
+            $req = $qb->execute();
+            $uri = null;
+            $principaluri = null;
+            while ($row = $req->fetch()) {
+                $uri = $row['uri'];
+                $principaluri = $row['principaluri'];
+            }
+            $req->closeCursor();
+            $qb = $qb->resetQueryParts();
+            // then check its {http://owncloud.org/ns}enabled property in oc_properties
+            if ($uri !== null) {
+                $propertypath = str_replace('principals/users/', 'addressbooks/users/', $principaluri) . '/' . $uri;
+                $qb->select('propertyvalue')
+                    ->from('properties')
+                    ->where($qb->expr()->eq('propertypath', $qb->createNamedParameter($propertypath, IQueryBuilder::PARAM_STR)))
+                    ->andWhere($qb->expr()->eq('propertyname', $qb->createNamedParameter('{http://owncloud.org/ns}enabled', IQueryBuilder::PARAM_STR)));
+                $req = $qb->execute();
+                $propertyvalue = null;
+                while ($row = $req->fetch()) {
+                    $propertyvalue = intval($row['propertyvalue']);
+                }
+                $req->closeCursor();
+                $qb = $qb->resetQueryParts();
+
+                $bookIsEnabled[$bookid] = ($propertyvalue === null or $propertyvalue === 1);
+            }
+        }
+        return $bookIsEnabled;
+    }
+
     private function N2FN(string $n) {
         if ($n) {
             $spl = explode($n, ';');
@@ -141,7 +192,21 @@ class ContactsController extends Controller {
         $booksReadOnly = $this->getAddressBooksReadOnly();
         $result = [];
         $userid = trim($this->userId);
+
+        // get addressbook ids
+        $bookids = [];
         foreach ($contacts as $c) {
+            if (!in_array($c['addressbook-key'], $bookids)) {
+                array_push($bookids, $c['addressbook-key']);
+            }
+        }
+        // determine if addressbooks are enabled
+        $bookIsEnabled = $this->getBookIsEnabled($bookids);
+
+        foreach ($contacts as $c) {
+            if (!$bookIsEnabled[$c['addressbook-key']]) {
+                continue;
+            }
             $uid = trim($c['UID']);
             // we don't give users, just contacts
             if (strcmp($c['URI'], 'Database:'.$c['UID'].'.vcf') !== 0 and


### PR DESCRIPTION
As mentioned in #169, contacts from disabled address books were showed on the map and suggested when placing contacts. Address book state is now verified from the database.