### PR TITLE
use standalone Viewer app when clicking on photo

### DIFF
--- a/js/photosController.js
+++ b/js/photosController.js
@@ -110,10 +110,16 @@ PhotosController.prototype = {
         var _app = this;
         return function(evt) {
             var marker = evt.layer;
-            var galleryUrl = OC.generateUrl('/apps/gallery/#'+encodeURIComponent(marker.data.path.replace(/^\//, '')));
-            var win = window.open(galleryUrl, '_blank');
-            if (win) {
-                win.focus();
+            // use Viewer app if available and recent enough to provide standalone viewer
+            if (OCA.Viewer && OCA.Viewer.open) {
+                OCA.Viewer.open(marker.data.path);
+            }
+            else {
+                var galleryUrl = OC.generateUrl('/apps/gallery/#'+encodeURIComponent(marker.data.path.replace(/^\//, '')));
+                var win = window.open(galleryUrl, '_blank');
+                if (win) {
+                    win.focus();
+                }
             }
         };
     },

--- a/js/photosController.js
+++ b/js/photosController.js
@@ -13,6 +13,7 @@ function PhotosController (optionsController, timeFilterController) {
     this.timeFilterEnd = Date.now();
 
     this.movingPhotoPath = null;
+    this.isPhotosInstalled = OCP.InitialState.loadState('maps', 'photos');
 }
 
 PhotosController.prototype = {
@@ -115,7 +116,14 @@ PhotosController.prototype = {
                 OCA.Viewer.open(marker.data.path);
             }
             else {
-                var galleryUrl = OC.generateUrl('/apps/gallery/#'+encodeURIComponent(marker.data.path.replace(/^\//, '')));
+                var galleryUrl;
+                if (_app.isPhotosInstalled) {
+                    var dir = OC.dirname(marker.data.path);
+                    galleryUrl = OC.generateUrl('/apps/photos/albums/' + dir.replace(/^\//, ''));
+                }
+                else {
+                    galleryUrl = OC.generateUrl('/apps/gallery/#' + encodeURIComponent(marker.data.path.replace(/^\//, '')));
+                }
                 var win = window.open(galleryUrl, '_blank');
                 if (win) {
                     win.focus();

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -16,15 +16,21 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Controller;
+use OCP\IInitialStateService;
 
 class PageController extends Controller {
     private $userId;
     private $config;
 
-    public function __construct($AppName, IRequest $request, $UserId, IConfig $config){
+    public function __construct($AppName,
+                                IRequest $request,
+                                $UserId,
+                                IConfig $config,
+                                IInitialStateService $initialStateService){
         parent::__construct($AppName, $request);
         $this->userId = $UserId;
         $this->config = $config;
+        $this->initialStateService = $initialStateService;
     }
 
     /**
@@ -39,6 +45,7 @@ class PageController extends Controller {
      */
     public function index() {
         $params = array('user' => $this->userId);
+        $this->initialStateService->provideInitialState($this->appName, 'photos', $this->config->getAppValue('photos', 'enabled', 'no') === 'yes');
         $response = new TemplateResponse('maps', 'index', $params);
         if (class_exists('OCP\AppFramework\Http\ContentSecurityPolicy')) {
             $csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();

--- a/templates/content/index.php
+++ b/templates/content/index.php
@@ -30,6 +30,7 @@ style('maps', '../node_modules/leaflet-contextmenu/dist/leaflet.contextmenu.min'
 style('maps', '../node_modules/leaflet.elevation/dist/Leaflet.Elevation-0.0.2');
 style('maps', '../node_modules/mapbox-gl/dist/mapbox-gl');
 style('maps', 'fontawesome/css/all.min');
+script('viewer', 'viewer');
 script('maps', '../node_modules/leaflet/dist/leaflet');
 script('maps', '../node_modules/leaflet.markercluster/dist/leaflet.markercluster');
 script('maps', '../node_modules/leaflet.featuregroup.subgroup/dist/leaflet.featuregroup.subgroup');


### PR DESCRIPTION
As mentioned in https://github.com/nextcloud/viewer/issues/157 it's now possible to use Viewer app in other apps as it's not strongly depending on Files app anymore.

So now, if Viewer app is recent enough, it's used directly in Maps when a photo is clicked. Otherwise a new tab to Gallery app is opened.

If you wanna try it, install a recent version of the Viewer app. I used `v18.0.0beta3`.

closes #93 