### PR TITLE
bumped version to 0.1.5

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 - **📱 Devices:** Lost your phone? Check the map!
 - **〰 Tracks:** Load GPS tracks or past trips. Recording with [PhoneTrack](https://f-droid.org/en/packages/net.eneiluj.nextcloud.phonetrack/) or [OwnTracks](https://owntracks.org) is planned.
 	]]></description>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <licence>agpl</licence>
     <author mail="eneiluj@posteo.net">Julien Veyssier</author>
     <author mail="kontakt+github@arne.email">Arne Hamann</author>


### PR DESCRIPTION
I failed to reupload v0.1.4. 
**Edit: Upload of new v0.1.4** tarball worked. Extraction still fails

So lets merge
- [ ] #253 
- [x] #281
- [x] #299
- [x] #241 
- [x] #251 
- [x] #292

Optional:
- [ ] #217 
- [x] #243
- [x] #263

and go for a hopfully working v0.1.5.
