### PR TITLE
Use global jQuery for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4241,11 +4241,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
-    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "d3": "^3.5.17",
     "i18next-client": "^1.11.4",
     "install": "^0.13.0",
-    "jquery": "^3.4.1",
     "leaflet": "^1.4.0",
     "leaflet-contextmenu": "^1.4.0",
     "leaflet-control-geocoder": "^1.7.0",

--- a/src/adminSettings.js
+++ b/src/adminSettings.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from "@nextcloud/router";
 
 (function() {

--- a/src/contactsController.js
+++ b/src/contactsController.js
@@ -1,5 +1,3 @@
-import $ from 'jquery'
-
 import { generateUrl } from '@nextcloud/router';
 
 import { basename, formatAddress } from './utils';

--- a/src/devicesController.js
+++ b/src/devicesController.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from '@nextcloud/router';
 
 import { Timer, brify, isComputer, isPhone, getDeviceInfoFromUserAgent2 } from './utils';

--- a/src/favoritesController.js
+++ b/src/favoritesController.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from '@nextcloud/router';
 
 import { Timer, getLetterColor, hslToRgb } from './utils';

--- a/src/filetypes.js
+++ b/src/filetypes.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from '@nextcloud/router';
 
 $(document).ready(function() {

--- a/src/nonLocalizedPhotosController.js
+++ b/src/nonLocalizedPhotosController.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from '@nextcloud/router';
 
 function NonLocalizedPhotosController (optionsController, timeFilterController, photosController) {

--- a/src/photosController.js
+++ b/src/photosController.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from '@nextcloud/router';
 
 import { basename } from './utils';

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,3 @@
-import jQuery from 'jquery';
-
 /**
  * Nextcloud - Maps
  *

--- a/src/tracksController.js
+++ b/src/tracksController.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { generateUrl } from '@nextcloud/router';
 
 import { dirname, brify, metersToDistance, metersToElevation, kmphToSpeed, minPerKmToPace, formatTimeSeconds, getUrlParameter } from './utils';


### PR DESCRIPTION
As it turns out, we still need to use the global jQuery else we get CSRF errors. :cry: 

Especially since the global jQuery is being deprecated (nextcloud/server#19386), we need to move away from using it ASAP but this is a quick fix so we can get `0.1.5` out and fix the unable to unpack issue. Let's switch to using `@nextcloud/axios` before the release of Nextcloud 19.