### PR TITLE
fix a few undeclared vars preventing search to work

### DIFF
--- a/src/favoritesController.js
+++ b/src/favoritesController.js
@@ -1177,7 +1177,7 @@ FavoritesController.prototype = {
 
     getAutocompData: function() {
         var that = this;
-        var fav, favid;
+        var fav, layer;
         var data = [];
         if (that.map.hasLayer(that.cluster)) {
             for (var cat in this.categoryLayers) {

--- a/src/script.js
+++ b/src/script.js
@@ -499,6 +499,7 @@ import { brify, getUrlParameter, formatAddress } from './utils';
         locControl: undefined,
         baseLayers: undefined,
         displaySearchResult: function(results) {
+            var that = this;
             this.searchMarkerLayerGroup.clearLayers();
             var result, searchMarker;
             for (var i=0; i < results.length; i++) {
@@ -510,6 +511,9 @@ import { brify, getUrlParameter, formatAddress } from './utils';
                 // popup
                 var popupContent = searchController.parseOsmResult(result);
                 searchMarker.bindPopup(popupContent, {className: 'search-result-popup'});
+                searchMarker.on('click', function () {
+                    that.map.clickpopup = true;
+                });
                 // tooltip
                 var name = '';
                 if (result.namedetails && result.namedetails.name) {

--- a/src/tracksController.js
+++ b/src/tracksController.js
@@ -1100,7 +1100,7 @@ TracksController.prototype = {
 
     getAutocompData: function() {
         var that = this;
-        var marker, devid;
+        var track, trackid;
         var data = [];
         if (this.map.hasLayer(this.mainLayer)) {
             for (trackid in this.tracks) {


### PR DESCRIPTION
Weird that there was no issue mentioning this problem. Search is now working again.

I also added a further fix depending on this one: when a search result popup was displayed and there is a click on the map, instead of closing the popup, the "location" popup was displayed.