### PR TITLE
photo group in viewer better sorted by date

### DIFF
--- a/src/photosController.js
+++ b/src/photosController.js
@@ -45,7 +45,8 @@ PhotosController.prototype = {
                     var photolist = a.layer.getAllChildMarkers().map(function(m) {
                         return  m.data;
                     });
-                    OCA.Viewer.open({path: a.layer.getAllChildMarkers()[0].data.path, list: photolist });
+                    photolist.sort(function (a, b) { return a.dateTaken - b.dateTaken;});
+                    OCA.Viewer.open({path: photolist[0].path, list: photolist });
                 } else {
                     a.layer.spiderfy();
                     that.map.clickpopup = true;


### PR DESCRIPTION
while discussing pros vs cons of #293 it came up that click on a group of photos will show photos in viewer in random order. This is a little fix to show photos instead sorted by date.
Signed-off-by: wronny <forum@wron.de>