### PR TITLE
Catch non numeric warning from pel

### DIFF
--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -376,7 +376,7 @@ class PhotofilesService {
         if (!$this->hasValidExifGeoTags($exif)) {
             try {
                 $exif = $this->getExifPelBackup($file);
-            } catch (PelException $exception) {
+            } catch (PelException | E_WARNING $exception) {
                 $exif = [];
             }
 

--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -162,7 +162,7 @@ class PhotofilesService {
             $this->photoMapper->deleteByFileIdUserId($fileId, $userId);
         }
     }
-    
+
 
     public function deleteByFolder(Node $folder) {
         $photos = $this->gatherPhotoFiles($folder, true);
@@ -375,8 +375,8 @@ class PhotofilesService {
 
         if (!$this->hasValidExifGeoTags($exif)) {
             try {
-                $exif = $this->getExifPelBackup($file);
-            } catch (PelException | E_WARNING $exception) {
+                @$exif = $this->getExifPelBackup($file);
+            } catch (PelException $exception) {
                 $exif = [];
             }
 


### PR DESCRIPTION
This PR silences the warning discussed in #245 
It is fine to just skip the picture as no sample picture had valid geo information. This way the log is not spammed.

 
Signed-off-by: Arne Hamann <kontakt+github@arne.email>
