### PR TITLE
fix issue #367

### DIFF
--- a/src/photosController.js
+++ b/src/photosController.js
@@ -324,7 +324,14 @@ PhotosController.prototype = {
 
         // we update the counter
         var catCounter = $('#navigation-photos .app-navigation-entry-utils-counter');
-        catCounter.text(this.photoMarkers.length);
+        var photoCounter = this.photoMarkers.length;
+        if ( photoCounter >= 10000 ){
+            catCounter.attr('title', photoCounter + ' photos');
+            photoCounter = photoCounter = Math.floor(photoCounter / 1000) ;
+            catCounter.text( photoCounter + 'k');
+        }else{
+            catCounter.text(photoCounter);
+        }
 
         // we put them all in the layer
         this.photoMarkersFirstVisible = 0;


### PR DESCRIPTION
This is an approach to fix issue #367 internally in maps without changing global styles. Result should look like follows using title tag to show accurate image count on mouse over:
![2020-05-14 00_08_45-Ausschneiden und skizzieren](https://user-images.githubusercontent.com/3709024/81873848-ddecfa00-957c-11ea-9864-08142f4512e9.jpg)
While @eneiluj was suggested as reviewer I also added @jancborchardt because as far as I can see he is very much involved in design and styles.
Signed-off-by: wronny <github@wron.de>