### PR TITLE
Fixes to sharing link page

### DIFF
--- a/src/PublicFavoriteShare.vue
+++ b/src/PublicFavoriteShare.vue
@@ -86,13 +86,6 @@ export default {
 </script>
 
 <style lang="scss">
-/* Override header style */
-#header {
-    .header-shared-by {
-        color: var(--color-primary-text);
-    }
-}
-
 #content {
     height: 100%;
 }

--- a/src/PublicFavoriteShare.vue
+++ b/src/PublicFavoriteShare.vue
@@ -72,6 +72,7 @@ export default {
 
 	mounted() {
 		this.getFavorites()
+		this.moveFooter()
 	},
 
 	methods: {
@@ -81,6 +82,11 @@ export default {
 			updateFavorite: `${PUBLIC_FAVORITES_NAMESPACE}/updateFavorite`,
 			deleteFavorite: `${PUBLIC_FAVORITES_NAMESPACE}/deleteFavorite`,
 		}),
+		// Place the footer in the app-navigation so it is not below the map
+		moveFooter() {
+			const footer = document.getElementsByTagName('footer')[0]
+			document.getElementById('app-navigation').appendChild(footer)
+		},
 	},
 }
 </script>
@@ -92,5 +98,22 @@ export default {
 
 * {
     box-sizing: content-box;
+}
+
+// Special CSS for placing the footer in the app-navigation
+#body-public #app-navigation {
+    ul {
+        margin-bottom: 70px;
+    }
+
+    footer {
+        display: block;
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        background-color: var(--color-main-background);
+        z-index: 100;
+        height: 65px;
+    }
 }
 </style>

--- a/src/components/map/FavoritePopup.vue
+++ b/src/components/map/FavoritePopup.vue
@@ -56,12 +56,8 @@
 			</div>
 		</form>
 		<div class="no-edits">
-			<p>
-				{{
-					favorite.comment.length
-						? favorite.comment
-						: t("maps", "No comment")
-				}}
+			<p v-if="favorite.comment">
+				{{ favorite.comment }}
 			</p>
 		</div>
 	</Popup>


### PR DESCRIPTION
- Fix popup not showing anything in favorite shares
- Remove outdated CSS overwriting core styles which have been fixed
- Favorite share: Place the footer in the app-navigation so it is not below the map

What I’d still like to fix, or if anyone can answer the questions:
- [ ] It would look much better if the map would zoom to the bounds of the favorites layer. How is that possible? (I found the `this.map.fitBounds(catLayer.getBounds(), {padding: [30, 30]});` function but don’t know how to get the layer, and neither how to get the map)
- [ ] When logged in, it uses Mapbox layers as configured. But in the share view the standard OpenStreetMap layer is used. Why is that?