### PR TITLE
increase length of maps_tracks metadata

### DIFF
--- a/lib/Migration/Version000107Date20200608220000.php
+++ b/lib/Migration/Version000107Date20200608220000.php
@@ -42,7 +42,7 @@ class Version000107Date20200608220000 extends SimpleMigrationStep {
 		if ($schema->hasTable('maps_tracks')) {
 			$table = $schema->getTable('maps_tracks');
 			$table->changeColumn('metadata', [
-				'notnull' => true,
+				'notnull' => false,
 				'length' => 1000,
 			]);
 		}

--- a/lib/Migration/Version000107Date20200608220000.php
+++ b/lib/Migration/Version000107Date20200608220000.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Maps\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use OCP\IDBConnection;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version000107Date20200608220000 extends SimpleMigrationStep {
+
+	protected $db;
+
+	public function __construct(IDBConnection $connection) {
+		$this->db = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('maps_tracks')) {
+			$table = $schema->getTable('maps_tracks');
+			$table->changeColumn('metadata', [
+				'notnull' => true,
+				'length' => 1000,
+			]);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+}


### PR DESCRIPTION
as identified in #377 metadata of track can be longer than 500. As far as I understood from documentation this should increase length of metadata to 1000.
added reviewers based on contributors of lib/Migration
Signed-off-by: wronny <forum@wron.de>