### PR TITLE
Fixes #193 - Handle storage exceptions on occ scan import

### DIFF
--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -329,7 +329,13 @@ class PhotofilesService {
                         continue;
                     }
                 }
-                $notes = array_merge($notes, $this->gatherPhotoFiles($node, $recursive));
+                try {
+                        $notes = array_merge($notes, $this->gatherPhotoFiles($node, $recursive));
+                } catch (\OCP\Files\StorageNotAvailableException | \Exception $e) {
+                        $msg = "WARNING: Could not access " . $node->getName();
+                        echo($msg . "\n");
+                        $this->logger->error($msg);
+                }
                 continue;
             }
             if ($this->isPhoto($node)) {

--- a/lib/Service/TracksService.php
+++ b/lib/Service/TracksService.php
@@ -171,7 +171,13 @@ class TracksService {
         $nodes = $folder->getDirectoryListing();
         foreach ($nodes as $node) {
             if ($node->getType() === FileInfo::TYPE_FOLDER AND $recursive) {
-                $notes = array_merge($notes, $this->gatherTrackFiles($node, $recursive));
+                try {
+                        $notes = array_merge($notes, $this->gatherTrackFiles($node, $recursive));
+                } catch (\OCP\Files\StorageNotAvailableException | \Exception $e) {
+                        $msg = "WARNING: Could not access " . $node->getName();
+                        echo($msg . "\n");
+                        $this->logger->error($msg);
+                }
                 continue;
             }
             if ($this->isTrack($node)) {


### PR DESCRIPTION
Fixes #193 .

Fixes the issue where scans are aborted when some storage or share is unavailable.  This fix instead handles the exception, logs the affected storage, and then continues the scan operation.