### PR TITLE
Fix loading mapbox-gl in NC 20

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -111,6 +111,8 @@ class PageController extends Controller {
             $csp->addAllowedConnectDomain('https://api.mapbox.com');
             $csp->addAllowedConnectDomain('https://events.mapbox.com');
             $csp->addAllowedConnectDomain('https://graphhopper.com');
+
+            $csp->addAllowedChildSrcDomain("blob:");
             // allow connections to custom routing engines
             $urlKeys = [
                 'osrmBikeURL',


### PR DESCRIPTION
Mapbox-gl script is not loaded in NC 20 because of a change in script-src directive. This makes it work again.