### PR TITLE
fix declaration of object_uri DB field

### DIFF
--- a/lib/Migration/Version000013Date20190723185417.php
+++ b/lib/Migration/Version000013Date20190723185417.php
@@ -44,7 +44,7 @@ class Version000013Date20190723185417 extends SimpleMigrationStep {
 			$table->dropColumn('contact_uid');
 			$table->addColumn('object_uri', 'string', [
 				'notnull' => true,
-				'default' => '',
+				'default' => '--',
 				'length' => 64,
 			]);
 			$table->addIndex(['object_uri'], 'maps_object_uri');

--- a/lib/Migration/Version000102Date20190901152326.php
+++ b/lib/Migration/Version000102Date20190901152326.php
@@ -43,7 +43,7 @@ class Version000102Date20190901152326 extends SimpleMigrationStep {
 			$table = $schema->getTable('maps_address_geo');
 			$table->changeColumn('object_uri', [
 				'notnull' => true,
-				'default' => '',
+				'default' => '--',
 				'length' => 255,
 			]);
 		}


### PR DESCRIPTION
This was making the installation crash on instance where Maps was never installed (all migration scripts running).

Strange that we didn't bump into that earlier. Anyway, old migration scripts run fine on fresh install now.

`object_uri` column is always affected when inserting/updating `maps_address_geo` table anyway.