### PR TITLE
Fix db-related install problems on NC 21

### DIFF
--- a/lib/Migration/Version000009Date20190625000800.php
+++ b/lib/Migration/Version000009Date20190625000800.php
@@ -42,12 +42,10 @@ class Version000009Date20190625000800 extends SimpleMigrationStep {
 			$table->addColumn('adr', 'string', [
 				'notnull' => true,
 				'length' => 255,
-				'unique' => true,
 			]);
 			$table->addColumn('adr_norm', 'string', [
 				'notnull' => true,
 				'length' => 255,
-				'unique' => true,
 			]);
 			$table->addColumn('lat', 'float', [
 				'notnull' => false,

--- a/lib/Migration/Version000012Date20190722184716.php
+++ b/lib/Migration/Version000012Date20190722184716.php
@@ -46,11 +46,6 @@ class Version000012Date20190722184716 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 41,
 			]);
-			$table->addColumn('contact_uid', 'string', [
-				'notnull' => true,
-				'default' => '',
-				'length' => 64,
-			]);
 			$table->addColumn('adr', 'string', [
 				'notnull' => true,
 				'default' => '',
@@ -75,7 +70,6 @@ class Version000012Date20190722184716 extends SimpleMigrationStep {
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['adr'], 'maps_adr');
 			$table->addIndex(['adr_norm'], 'maps_adr_norm');
-			$table->addIndex(['contact_uid'], 'maps_contact_uid');
 		}
 
 		return $schema;

--- a/lib/Migration/Version000013Date20190723185417.php
+++ b/lib/Migration/Version000013Date20190723185417.php
@@ -41,7 +41,9 @@ class Version000013Date20190723185417 extends SimpleMigrationStep {
 
 		if ($schema->hasTable('maps_address_geo')) {
 			$table = $schema->getTable('maps_address_geo');
-			$table->dropColumn('contact_uid');
+			if ($table->hasColumn('contact_uid')) {
+				$table->dropColumn('contact_uid');
+			}
 			$table->addColumn('object_uri', 'string', [
 				'notnull' => true,
 				'default' => '--',


### PR DESCRIPTION
I guess upgrading NC dependencies causes the 'unique' problem, this has probably been removed from the DB connector.

But I don't know where the 'contact_uid' problem comes from. Anyway it can be fixed by not adding it as we get rid of it later anyway.

We could publish after that as it apparently happens with all DB types.

refs #541 