### PR TITLE
Add GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+on:
+  push:
+    branches: [release]
+
+name: Publish release
+
+jobs:
+  build:
+    name: Build, upload and release in the appstore
+    environment: release
+    env:
+      APP_ID: maps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, sqlite3
+          ini-values: post_max_size=256M, max_execution_time=180
+          coverage: xdebug
+          tools: php-cs-fixer, phpunit
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get current tag
+        id: tag
+        run: |
+          git fetch --tags --force
+          tag=$(git tag -l --points-at HEAD)
+          vtag=$(echo $tag | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+" || echo "")
+          echo "##[set-output name=currenttag;]$vtag"
+
+      - name: Build project
+        if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
+        id: build_release
+        run: |
+          echo "##[set-output name=app_id;]$APP_ID"
+          echo "###### copy app certificate"
+          mkdir -p ~/.nextcloud/certificates
+          echo "$APP_CRT" > ~/.nextcloud/certificates/${APP_ID}.crt
+          echo "$APP_KEY" > ~/.nextcloud/certificates/${APP_ID}.key
+          echo "###### install dependencies"
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt update -y
+          #sudo apt upgrade -y
+          sudo apt install make openssl -y
+          echo "###### installing nextcloud"
+          mkdir ~/html
+          git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b master ~/html/nextcloud
+          sed -i $'s|if (substr($fullPath, 0, strlen($root) + 1) === $root . \'/\')|if (is_string($root) and substr($fullPath, 0, strlen($root) + 1) === $root . \'/\')|g' ~/html/nextcloud/lib/autoloader.php
+          cp -r $GITHUB_WORKSPACE ~/html/nextcloud/apps/${APP_ID}
+          php ~/html/nextcloud/occ maintenance:install --database "sqlite" --admin-user "admin" --admin-pass "password"
+          php ~/html/nextcloud/occ app:enable ${APP_ID}
+          php ~/html/nextcloud/occ maintenance:mode --off
+          cd ~/html/nextcloud/apps/${APP_ID}
+          echo "###### make"
+          webserveruser=runner occ_dir=~/html/nextcloud make > /dev/null
+          echo "###### make appstore"
+          tag=${{ steps.tag.outputs.currenttag }}
+          version=${tag/v/}
+          webserveruser=runner occ_dir=~/html/nextcloud version=$version make build_release
+          echo "##[set-output name=version;]$version"
+        env:
+          APP_CRT: ${{ secrets.APP_CRT }}
+          APP_KEY: ${{ secrets.APP_KEY }}
+
+      - name: Create Release
+        if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.currenttag }}
+          release_name: ${{ steps.tag.outputs.currenttag }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) }}
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/build/${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
+          asset_name: ${{ steps.build_release.outputs.app_id }}-${{ steps.build_release.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Publish normal release to appstore
+        if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) && !endsWith( steps.tag.outputs.currenttag , 'nightly' ) }}
+        id: publish
+        run: |
+          SIGNATURE=$(cat /tmp/build/sign.txt | tr -d '\n')
+          VERSION=${{ steps.build_release.outputs.version }}
+          DOWNLOAD_URL=https://github.com/${{ github.repository }}/releases/download/v${VERSION}/${APP_ID}-${VERSION}.tar.gz
+          curl -X POST -H "Authorization: Token $APPSTORE_TOKEN" https://apps.nextcloud.com/api/v1/apps/releases -H "Content-Type: application/json" -d '{"download":"'${DOWNLOAD_URL}'", "signature": "'${SIGNATURE}'"}'
+        env:
+          APPSTORE_TOKEN: ${{ secrets.APPSTORE_TOKEN }}
+
+      - name: Publish nightly release to appstore
+        if: ${{ startsWith( steps.tag.outputs.currenttag , 'v' ) && endsWith( steps.tag.outputs.currenttag , 'nightly' ) }}
+        id: nightly
+        run: |
+          SIGNATURE=$(cat /tmp/build/sign.txt | tr -d '\n')
+          VERSION=${{ steps.build_release.outputs.version }}
+          DOWNLOAD_URL=https://github.com/${{ github.repository }}/releases/download/v${VERSION}/${APP_ID}-${VERSION}.tar.gz
+          curl -X POST -H "Authorization: Token $APPSTORE_TOKEN" https://apps.nextcloud.com/api/v1/apps/releases -H "Content-Type: application/json" -d '{"download":"'${DOWNLOAD_URL}'", "signature": "'${SIGNATURE}'", "nightly": true}'
+        env:
+          APPSTORE_TOKEN: ${{ secrets.APPSTORE_TOKEN }}


### PR DESCRIPTION
This action is triggered when pushing to the `release` branch. It runs in a protected environment requiring review from @tacruc or @jancborchardt or me. The app certificate/key and the appstore token secrets are safe there.

To make it publish a release, latest commit has to be tagged with a tag which name begins with "v". I f the tag ends with "nightly" it will publish a...nightly.

It takes care of building the app, creating a release on GitHub with the release production archive and then publishing on the appstore.