### PR TITLE
Fix loading of tracks

### DIFF
--- a/src/tracksController.js
+++ b/src/tracksController.js
@@ -291,7 +291,7 @@ TracksController.prototype = {
             html: ''
         });
         this.tracks[track.id] = track;
-        this.tracks[track.id].metadata = $.parseJSON(track.metadata);
+        this.tracks[track.id].metadata = track.metadata === '' ? {} : $.parseJSON(track.metadata);
         this.tracks[track.id].icon = L.divIcon(L.extend({
             html: '<div class="thumbnail"></div>​',
             className: 'leaflet-marker-track track-marker track-marker-'+track.id


### PR DESCRIPTION
The flow seems to be:
```
occ maps:scan-tracks
```
adds the tracks to the db with `$metadata = ""`. Then, when the UI
initially requests a specific track the metadata is generated. This
however never happens since the UI code attempts to parse the metadata
as JSON before. Fixed by checking for an empty string before (in which
case we return an empty object (the metadata will be read again later
when displaying an individual track)).

I am not sure why the metadata is read here it all. Maybe the parsing
call be be removed completly if it happens again later anyway?

Fixes: #574