### PR TITLE
v0.1.9

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
+indent_style = tab
 indent_size = 4
 end_of_line = lf
 insert_final_newline = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt install make openssl -y
           echo "###### installing nextcloud"
           mkdir ~/html
-          git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b master ~/html/nextcloud
+          git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b stable21 ~/html/nextcloud
           sed -i $'s|if (substr($fullPath, 0, strlen($root) + 1) === $root . \'/\')|if (is_string($root) and substr($fullPath, 0, strlen($root) + 1) === $root . \'/\')|g' ~/html/nextcloud/lib/autoloader.php
           cp -r $GITHUB_WORKSPACE ~/html/nextcloud/apps/${APP_ID}
           php ~/html/nextcloud/occ maintenance:install --database "sqlite" --admin-user "admin" --admin-pass "password"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## 0.1.9 – 2021-06-29
+### Added
+- GitHub automated release action
+
+### Fixed
+- fix tracks not loading
+  [#587](https://github.com/nextcloud/maps/pull/587) @Ablu
+  [#574](https://github.com/nextcloud/maps/issues/574) @Tazzios
+- fix images not loading
+  [#559](https://github.com/nextcloud/maps/pull/559) @tacruc
+  [#543](https://github.com/nextcloud/maps/issues/543) @beardhatcode
+- fix db-related install problems on NC 21
+  [#568](https://github.com/nextcloud/maps/pull/568) @eneiluj
+  [#541](https://github.com/nextcloud/maps/issues/541) @J0WI
+
 ## 0.1.8 – 2020-10-03
 ### Fixed
 - controllers not being declared soon enough in some cases

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/maps/master/screenshots/screenshot3.png</screenshot>
     <dependencies>
         <lib>exif</lib>
-        <nextcloud min-version="20" max-version="22"/>
+        <nextcloud min-version="20" max-version="23"/>
     </dependencies>
     <repair-steps>
         <install>

--- a/lib/Migration/Version000009Date20190625000800.php
+++ b/lib/Migration/Version000009Date20190625000800.php
@@ -56,7 +56,8 @@ class Version000009Date20190625000800 extends SimpleMigrationStep {
 				'length' => 10,
 			]);
 			$table->addColumn('looked_up', 'boolean', [
-				'notnull' => true,
+				'notnull' => false,
+				'default' => false,
 			]);
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['adr'], 'maps_adr');

--- a/lib/Migration/Version000012Date20190722184716.php
+++ b/lib/Migration/Version000012Date20190722184716.php
@@ -65,7 +65,8 @@ class Version000012Date20190722184716 extends SimpleMigrationStep {
 				'length' => 10,
 			]);
 			$table->addColumn('looked_up', 'boolean', [
-				'notnull' => true,
+				'notnull' => false,
+				'default' => false,
 			]);
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['adr'], 'maps_adr');


### PR DESCRIPTION
Hey there,

As 22 is close, it would be nice to have a compatible Maps release. Isn't it? :grin:

* It was not possible to install the app on 22 because of new DB migration checks. A boolean column can't be `NotNull` anymore. A fix is included in this PR.
* The track loading fix was merged (https://github.com/nextcloud/maps/pull/587)
* The image loading fix is there too (https://github.com/nextcloud/maps/pull/559)
* About the previous database fix (remove unique constraints which are not in server anymore https://github.com/nextcloud/maps/pull/568), I made a few tests to make sure it works fine for everybody
    * Fresh install on fresh 20, 21 and 22: ok :heavy_check_mark: 
    * Upgrade from 0.1.8 on 20: ok :heavy_check_mark: 
    * Is there any other use case that could go wrong? I couldn't reproduce the errors mentioned in the PR where some tables were missing. If someone gives me a set of actions to reproduce it I can work on a fix.

So the only sensitive thing in this release is the migration issue.

The [latest v0.1.9-11-nightly build](https://github.com/nextcloud/maps/releases/download/v0.1.9-11-nightly/maps-0.1.9-11-nightly.tar.gz) comes from this branch. You can use it for testing.