### PR TITLE
Add padding on icons/name

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -862,3 +862,7 @@ tr.selected td {
     border-radius: 2px;
   }
 }
+
+.device-name, .category-name, .icon-picture, .track-name {
+    padding-left: 44px !important;
+}


### PR DESCRIPTION
Hello, 
Here's a very quick fix to align elements on maps menu.

Fix #647

![image](https://user-images.githubusercontent.com/29704178/136709477-071075c3-3719-4daa-a8ea-de5d6d6e03a3.png)
