### PR TITLE
Webpack: force node sass due to /deep/ modifiers in scss source.

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -23,7 +23,13 @@ module.exports = {
 			},
 			{
 				test: /\.scss$/,
-				use: ['vue-style-loader', 'css-loader', 'sass-loader'],
+				use: ['vue-style-loader', 'css-loader', {
+					loader: 'sass-loader',
+					options: {
+						// Prefer `node-sass`
+						implementation: require('node-sass'),
+					},
+				}],
 			},
 			{
 				test: /src\/.*\.(js|vue)$/,


### PR DESCRIPTION
The style files contain /deep/ in some places which is not understood
dart-sass. OTOH dart-sass is preferred by npm. So rather force webpack
to use node-sass.

Signed-off-by: Claus-Justus Heine <himself@claus-justus-heine.de>