### PR TITLE
Add .contact-group-name to padding exception

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -863,6 +863,6 @@ tr.selected td {
   }
 }
 
-.device-name, .category-name, .icon-picture, .track-name {
+.device-name, .category-name, .icon-picture, .track-name, .contact-group-name {
     padding-left: 44px !important;
 }


### PR DESCRIPTION
I indeed forgot the padding for the contacts. 

Fixes https://github.com/nextcloud/maps/issues/647 (again)