### PR TITLE
fixes mapbox no panning, by downgrading mapbox-gl to 2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"leaflet.featuregroup.subgroup": "^1.0.2",
 				"leaflet.locatecontrol": "^0.76.1",
 				"lrm-graphhopper": "^1.3.0",
-				"mapbox-gl": "^2.8.2",
+				"mapbox-gl": "^2.4.1",
 				"mapbox-gl-leaflet": "^0.0.15",
 				"nouislider": "^14.0.2",
 				"opening_hours": "^3.8.0",
@@ -1986,9 +1986,9 @@
 			}
 		},
 		"node_modules/@mapbox/tiny-sdf": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-			"integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+			"integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
 		},
 		"node_modules/@mapbox/unitbezier": {
 			"version": "0.0.0",
@@ -8274,21 +8274,21 @@
 			}
 		},
 		"node_modules/mapbox-gl": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.8.2.tgz",
-			"integrity": "sha512-73TgEQlh15TF1UeYhej9Tz1iU4ZhuxIwM6t+e6MxaA7Mu9vqUCZc1kZtZRAXrVeMcDHBSO6gUUjeDBOnsUZVmQ==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.4.1.tgz",
+			"integrity": "sha512-iTF5UPm63ojEi91A2lSpM5wDfnttuPXJmJRwD65R4n2mAYoQjjRwXvXIgcxKDnZDpdczF1jIFeS1R+H8jp1NCQ==",
 			"dependencies": {
-				"@mapbox/geojson-rewind": "^0.5.1",
+				"@mapbox/geojson-rewind": "^0.5.0",
 				"@mapbox/geojson-types": "^1.0.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
 				"@mapbox/mapbox-gl-supported": "^2.0.0",
 				"@mapbox/point-geometry": "^0.1.0",
-				"@mapbox/tiny-sdf": "^2.0.2",
+				"@mapbox/tiny-sdf": "^1.2.5",
 				"@mapbox/unitbezier": "^0.0.0",
 				"@mapbox/vector-tile": "^1.3.1",
 				"@mapbox/whoots-js": "^3.1.0",
 				"csscolorparser": "~1.0.3",
-				"earcut": "^2.2.3",
+				"earcut": "^2.2.2",
 				"geojson-vt": "^3.2.1",
 				"gl-matrix": "^3.3.0",
 				"grid-index": "^1.1.0",
@@ -8298,9 +8298,9 @@
 				"potpack": "^1.0.1",
 				"quickselect": "^2.0.0",
 				"rw": "^1.3.3",
-				"supercluster": "^7.1.4",
+				"supercluster": "^7.1.3",
 				"tinyqueue": "^2.0.3",
-				"vt-pbf": "^3.1.3"
+				"vt-pbf": "^3.1.1"
 			}
 		},
 		"node_modules/mapbox-gl-leaflet": {
@@ -14057,9 +14057,9 @@
 			"integrity": "sha1-biWYB0SqIjMflLZFpULALT/P7pc="
 		},
 		"@mapbox/tiny-sdf": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-			"integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+			"integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
 		},
 		"@mapbox/unitbezier": {
 			"version": "0.0.0",
@@ -19104,21 +19104,21 @@
 			"peer": true
 		},
 		"mapbox-gl": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.8.2.tgz",
-			"integrity": "sha512-73TgEQlh15TF1UeYhej9Tz1iU4ZhuxIwM6t+e6MxaA7Mu9vqUCZc1kZtZRAXrVeMcDHBSO6gUUjeDBOnsUZVmQ==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.4.1.tgz",
+			"integrity": "sha512-iTF5UPm63ojEi91A2lSpM5wDfnttuPXJmJRwD65R4n2mAYoQjjRwXvXIgcxKDnZDpdczF1jIFeS1R+H8jp1NCQ==",
 			"requires": {
-				"@mapbox/geojson-rewind": "^0.5.1",
+				"@mapbox/geojson-rewind": "^0.5.0",
 				"@mapbox/geojson-types": "^1.0.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
 				"@mapbox/mapbox-gl-supported": "^2.0.0",
 				"@mapbox/point-geometry": "^0.1.0",
-				"@mapbox/tiny-sdf": "^2.0.2",
+				"@mapbox/tiny-sdf": "^1.2.5",
 				"@mapbox/unitbezier": "^0.0.0",
 				"@mapbox/vector-tile": "^1.3.1",
 				"@mapbox/whoots-js": "^3.1.0",
 				"csscolorparser": "~1.0.3",
-				"earcut": "^2.2.3",
+				"earcut": "^2.2.2",
 				"geojson-vt": "^3.2.1",
 				"gl-matrix": "^3.3.0",
 				"grid-index": "^1.1.0",
@@ -19128,9 +19128,9 @@
 				"potpack": "^1.0.1",
 				"quickselect": "^2.0.0",
 				"rw": "^1.3.3",
-				"supercluster": "^7.1.4",
+				"supercluster": "^7.1.3",
 				"tinyqueue": "^2.0.3",
-				"vt-pbf": "^3.1.3"
+				"vt-pbf": "^3.1.1"
 			}
 		},
 		"mapbox-gl-leaflet": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"leaflet.featuregroup.subgroup": "^1.0.2",
 		"leaflet.locatecontrol": "^0.76.1",
 		"lrm-graphhopper": "^1.3.0",
-		"mapbox-gl": "^2.8.2",
+		"mapbox-gl": "^2.4.1",
 		"mapbox-gl-leaflet": "^0.0.15",
 		"nouislider": "^14.0.2",
 		"opening_hours": "^3.8.0",


### PR DESCRIPTION
There is an Issue with mapbox-gl-leaflet in combination with mapbox-gl v2.5.1 https://github.com/mapbox/mapbox-gl-leaflet/issues/145 
Fixes #786.