### PR TITLE
fix graphhopper routing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ import { generateUrl } from '@nextcloud/router'
 
 // Fixing Some leaflet webpack stuff See https://vue2-leaflet.netlify.app/faq/#my-map-and-or-markers-don-t-fully-render-what-gives
 import L from 'leaflet'
+import 'lrm-graphhopper'
 import { isPublic } from './utils/common'
 delete L.Icon.Default.prototype._getIconUrl
 


### PR DESCRIPTION
The `lrm-graphhopper` node module doesn't get included by webpack because it's not imported in the javascript. Looks like the import in a vue template doesn't count. This PR simply fixes graphhopper routing that it will be shown in the selection.

Fixes #800