### PR TITLE
Removes all colons from generated track/route filename

### DIFF
--- a/src/components/map/routing/RoutingMachine.vue
+++ b/src/components/map/routing/RoutingMachine.vue
@@ -503,8 +503,8 @@ export default {
 				}
 			})
 			const name = type === 'route'
-				? t('maps', 'Route {date}', { date: moment().format('LLL:ss') }).replace(':', '')
-				: t('maps', 'Track {date}', { date: moment().format('LLL:ss') }).replace(':', '')
+				? t('maps', 'Route {date}', { date: moment().format('LLL:ss') }).replaceAll(':', '')
+				: t('maps', 'Track {date}', { date: moment().format('LLL:ss') }).replaceAll(':', '')
 			const totDist = this.control._selectedRoute.summary.totalDistance
 			const totTime = this.control._selectedRoute.summary.totalTime
 


### PR DESCRIPTION
Apparently, #923 wasn't fully fixed before, because 'replace()` only changes single occurrence in the string. Therefore, violating colon currently still appears in the filename. This PR should hopefully fix it for good