### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/AppNavigationDevicesItem.vue
+++ b/src/components/AppNavigationDevicesItem.vue
@@ -143,6 +143,6 @@ export default {
 }
 
 ::v-deep .no-color {
-	color: var(--color-primary);
+	color: var(--color-primary-element);
 }
 </style>

--- a/src/components/AppNavigationMyMapsItem.vue
+++ b/src/components/AppNavigationMyMapsItem.vue
@@ -98,7 +98,7 @@ export default {
 }
 
 ::v-deep .no-color {
-	color: var(--color-primary);
+	color: var(--color-primary-element);
 }
 
 ::v-deep .icon-maps-dark {

--- a/src/components/AppNavigationTracksItem.vue
+++ b/src/components/AppNavigationTracksItem.vue
@@ -185,6 +185,6 @@ export default {
 }
 
 ::v-deep .no-color {
-	background-color: var(--color-primary);
+	background-color: var(--color-primary-element);
 }
 </style>

--- a/src/components/map/Slider.vue
+++ b/src/components/map/Slider.vue
@@ -241,6 +241,6 @@ export default {
 }
 
 ::v-deep .noUi-connect {
-	background-color: var(--color-primary);
+	background-color: var(--color-primary-element);
 }
 </style>


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.