### PR TITLE
[To be disscussed] Disable maps for file drop links

### DIFF
--- a/lib/Controller/PublicPageController.php
+++ b/lib/Controller/PublicPageController.php
@@ -98,6 +98,12 @@ class PublicPageController extends AuthPublicShareController {
 			return false;
 		}
 
+		//Disable mymaps on file-drop links
+		$isReadable = ($share->getPermissions() & (1 << 0));
+		if (!$isReadable) {
+			return false;
+		}
+
 		return $share->getNode()->isReadable() && $share->getNode()->isShareable();
 	}
 

--- a/lib/Controller/PublicUtilsController.php
+++ b/lib/Controller/PublicUtilsController.php
@@ -177,6 +177,10 @@ class PublicUtilsController extends PublicPageController {
 		$share = $this->getShare();
 		$permissions = $share->getPermissions();
 		$folder = $this->getShareNode();
+		$isReadable = ($permissions & (1 << 0)) && $folder->isReadable();
+		if (!$isReadable) {
+			throw new NotPermittedException();
+		}
 		$isCreatable = ($permissions & (1 << 2)) && $folder->isCreatable();
 		try {
 			$file=$folder->get(".index.maps");
@@ -190,7 +194,7 @@ class PublicUtilsController extends PublicPageController {
 		$ov = json_decode($file->getContent(),true, 512);
 
 		// Maps content can be read mostly from the folder
-		$ov['isReadable'] = ($permissions & (1 << 0)) && $folder->isReadable();
+		$ov['isReadable'] = $isReadable;
 		//Saving maps information in the file
 		$ov['isUpdateable'] = ($permissions & (1 << 1)) && $file->isUpdateable();
 		$ov['isCreatable'] = ($permissions & (1 << 2)) && $folder->isCreatable();

--- a/src/models/copyMapsLinkAction.js
+++ b/src/models/copyMapsLinkAction.js
@@ -40,7 +40,7 @@ export default class CopyMapsLinkAction {
 	data({ share, fileInfo }) {
 		this._share = share
 		return {
-			is: NcActionButton,
+			is: share.hasReadPermission ? NcActionButton : null,
 			ariaLabel: t('maps', 'Copy link to map'),
 			icon: 'icon-clippy',
 			title: t('maps', 'Copy link to map'),


### PR DESCRIPTION
Currently file drop links can be opened with maps and favorites can be added, but files can not be viewed.
So a file drop link get a favorite drop map in the maps app.

This might be confusing https://github.com/nextcloud/maps/issues/1054#issuecomment-1600691897. This PR disables maps for file-drop links and hides the share action.

