### PR TITLE
Sidebar enhancements

### DIFF
--- a/src/components/FavoriteEditionForm.vue
+++ b/src/components/FavoriteEditionForm.vue
@@ -188,6 +188,7 @@ export default {
 		},
 		onDeleteClick() {
 			this.$emit('delete', this.favorite.id)
+			this.$emit('close')
 		},
 	},
 }

--- a/src/components/FavoriteEditionForm.vue
+++ b/src/components/FavoriteEditionForm.vue
@@ -19,7 +19,6 @@
 				:limit="8"
 				:options-limit="8"
 				:max-height="8 * 45"
-				:close-on-select="false"
 				:clear-on-select="false"
 				:preserve-search="false"
 				:placeholder="categoryPH"
@@ -42,7 +41,8 @@
 			<textarea v-model="comment"
 				:placeholder="commentPH"
 				:readonly="!favorite.isUpdateable"
-				rows="1" />
+				rows="1"
+				style="resize: vertical;" />
 			<span class="icon icon-address" />
 			<input
 				v-model="location"
@@ -57,7 +57,7 @@
 				type="primary"
 				@click="onOkClick">
 				<template>
-					{{ t('maps', 'OK') }}
+					{{ t('maps', 'Save') }}
 				</template>
 			</NcButton>
 			<NcButton :disabled="!favorite.isUpdateable"
@@ -202,9 +202,14 @@ export default {
 	display: grid;
 	grid-template: 1fr / 40px 1fr;
 
+	input {
+		height: auto !important;
+	}
+
 	input,
 	textarea {
 		width: 100%;
+		padding: 12px 10px;
 	}
 
 	span,
@@ -215,8 +220,25 @@ export default {
 	}
 }
 
+::v-deep .multiselect__tags {
+	border: 2px solid var(--color-border-maxcontrast) !important;
+
+	.multiselect__single {
+		color: var(--color-main-text) !important;
+	}
+
+	&:hover {
+		border-color: var(--color-primary-element) !important;
+	}
+}
+
 .buttons {
-	margin-top: 15px;
+	margin-top: 20px;
+
+	button {
+		width: 100%;
+		margin: 0px 5px !important;
+	}
 }
 
 .favorite-edition {

--- a/src/components/FavoriteEditionForm.vue
+++ b/src/components/FavoriteEditionForm.vue
@@ -188,7 +188,6 @@ export default {
 		},
 		onDeleteClick() {
 			this.$emit('delete', this.favorite.id)
-			this.$emit('close')
 		},
 	},
 }
@@ -207,6 +206,17 @@ export default {
 	textarea {
 		width: 100%;
 	}
+
+	span,
+	input,
+	textarea,
+	.multiselect {
+		margin-top: 10px;
+	}
+}
+
+.buttons {
+	margin-top: 15px;
 }
 
 .favorite-edition {

--- a/src/components/FavoriteSidebarTab.vue
+++ b/src/components/FavoriteSidebarTab.vue
@@ -6,7 +6,8 @@
 			:favorite="favorite"
 			:categories="categories"
 			@edit="$emit('edit', $event)"
-			@delete="$emit('delete', $event)" />
+			@delete="$emit('delete', $event)" 
+			@close="$emit('close')" />
 	</div>
 </template>
 

--- a/src/components/FavoriteSidebarTab.vue
+++ b/src/components/FavoriteSidebarTab.vue
@@ -6,8 +6,7 @@
 			:favorite="favorite"
 			:categories="categories"
 			@edit="$emit('edit', $event)"
-			@delete="$emit('delete', $event)" 
-			@close="$emit('close')" />
+			@delete="$emit('delete', $event)" />
 	</div>
 </template>
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,11 +9,15 @@
 		@closing="handleClosing"
 		@closed="handleClosed"
 		@close="$emit('close')">
+		<template v-slot:header>
+			<span :class="['header-icon icon', icon]" v-if="icon"></span>
+		</template>
 		<FavoriteSidebarTab v-if="activeTab === 'favorite'"
 			:favorite="favorite"
 			:categories="favoriteCategories"
 			@edit="$emit('edit-favorite', $event)"
-			@delete="$emit('delete-favorite', $event)" />
+			@delete="$emit('delete-favorite', $event)"
+			@close="$emit('close')" />
 		<PhotoSuggestionsSidebarTab v-if="activeTab === 'photo-suggestion' && !fileInfo"
 			:photo-suggestions="photoSuggestions"
 			:photo-suggestions-tracks-and-devices="photoSuggestionsTracksAndDevices"
@@ -167,6 +171,7 @@ export default {
 			isFullScreen: false,
 			typeOpened: '',
 			title: null,
+			icon: null,
 		}
 	},
 
@@ -250,33 +255,17 @@ export default {
 		},
 
 		/**
-		 * File background/figure to illustrate the sidebar header
-		 *
-		 * @return {string}
-		 */
-		background() {
-			const iconColor = OCA.Accessibility?.theme === 'dark' ? 'ffffff' : '000000'
-			if (this.typeOpened === 'track') {
-				return generateFilePath('maps', 'img', 'road.svg')
-			}
-			if (this.typeOpened === 'maps') {
-				return generateFilePath('maps', 'img', 'maps.png')
-			}
-			return this.getPreviewIfAny(this.fileInfo)
-		},
-
-		/**
 		 * App sidebar v-binding object
 		 *
 		 * @return {object}
 		 */
 		appSidebar() {
+			this.icon = null // Reset header icon
 			if (this.fileInfo) {
 				return {
 					'data-mimetype': this.fileInfo.mimetype,
 					'star-loading': this.starLoading,
 					active: this.activeTab,
-					background: this.background,
 					class: {
 						'app-sidebar--has-preview': this.fileInfo.hasPreview && !this.isFullScreen,
 						'app-sidebar--full': this.isFullScreen,
@@ -299,15 +288,14 @@ export default {
 				// no fileInfo yet, showing empty data
 				return {
 					loading: this.loading,
-					subtitle: t('maps', 'Shows cool information'),
-					title: t('maps', 'Sidebar'),
+					subtitle: '',
+					title: '',
 				}
 			} else if (this.activeTab === 'favorite') {
-				const iconColor = OCA.Accessibility?.theme === 'dark' ? 'ffffff' : '000000'
+				this.icon = 'icon-favorite'
 				return {
 					title: t('maps', 'Favorite'),
 					compact: true,
-					background: generateUrl('/svg/core/actions/star?color=' + iconColor),
 					subtitle: '',
 					active: this.activeTab,
 					class: {
@@ -316,11 +304,10 @@ export default {
 					},
 				}
 			} else if (this.activeTab === 'photo-suggestion') {
-				const iconColor = OCA.Accessibility?.theme === 'dark' ? 'ffffff' : '000000'
+				this.icon = 'icon-picture'
 				return {
 					title: t('maps', 'Photo suggestions'),
 					compact: true,
-					background: generateUrl('/apps/theming/img/core/filetypes/image.svg?color=' + iconColor),
 					subtitle: '',
 					active: this.activeTab,
 					class: {
@@ -329,11 +316,9 @@ export default {
 					},
 				}
 			} else if (this.activeTab === 'maps-track-metadata') {
-				const iconColor = OCA.Accessibility?.theme === 'dark' ? 'ffffff' : '000000'
 				return {
 					title: t('maps', 'Track metadata'),
 					compact: true,
-					background: this.background,
 					subtitle: '',
 					active: this.activeTab,
 					class: {
@@ -344,8 +329,8 @@ export default {
 			} else {
 				return {
 					loading: false,
-					subtitle: t('maps', 'Shows cool information'),
-					title: t('maps', 'Sidebar'),
+					subtitle: '',
+					title: '',
 				}
 			}
 		},
@@ -380,53 +365,6 @@ export default {
 			return OCA && 'SystemTags' in OCA
 		},
 	},
-
-	/*
-	sidebarTitle() {
-			if (this.activeTab === 'track') {
-				return t('maps', 'Track')
-			} else if (this.activeTab === 'favorite') {
-				return t('maps', 'Favorite')
-			} else if (this.activeTab === 'photo') {
-				return this.photo.basename
-			} else if (this.activeTab === 'photo-suggestion') {
-				return t('maps', 'Photo location suggestions')
-			} else if (this.activeTab === 'myMaps') {
-				return this.myMap.name
-			}
-			return t('maps', 'Sidebar')
-		},
-		sidebarSubtitle() {
-			if (this.activeTab === 'track') {
-				return ''
-			} else if (this.activeTab === 'favorite') {
-				return ''
-			} else if (this.activeTab === 'photo') {
-				return this.photo.filename
-			} else if (this.activeTab === 'photo-suggestion') {
-				return ''
-			} else if (this.activeTab === 'myMaps') {
-				return this.myMap.path ?? ''
-			}
-			return t('maps', 'Shows cool information')
-		},
-		backgroundImageUrl() {
-			const iconColor = OCA.Accessibility?.theme === 'dark' ? 'ffffff' : '000000'
-			if (this.activeTab === 'track') {
-				return generateUrl('/svg/maps/road?color=' + iconColor)
-			} else if (this.activeTab === 'favorite') {
-				return generateUrl('/svg/core/actions/star?color=' + iconColor)
-			} else if (this.activeTab === 'photo') {
-				return this.previewUrl()
-			} else if (this.activeTab === 'photo-suggestion') {
-				return generateUrl('/apps/theming/img/core/filetypes') + '/image.svg?v=2'
-			} else if (this.activeTab === 'myMaps') {
-				return generateFilePath('maps', 'img', 'maps.png')
-			}
-			return ''
-		},
-	}, */
-
 	watch: {
 	},
 	methods: {
@@ -697,5 +635,12 @@ export default {
 			fill: currentColor;
 		}
 	}
+}
+
+.header-icon {
+	display: block;
+	width: 70px;
+	height: 60px;
+	background-size: 40px 40px;
 }
 </style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -16,8 +16,7 @@
 			:favorite="favorite"
 			:categories="favoriteCategories"
 			@edit="$emit('edit-favorite', $event)"
-			@delete="$emit('delete-favorite', $event)"
-			@close="$emit('close')" />
+			@delete="$emit('delete-favorite', $event)" />
 		<PhotoSuggestionsSidebarTab v-if="activeTab === 'photo-suggestion' && !fileInfo"
 			:photo-suggestions="photoSuggestions"
 			:photo-suggestions-tracks-and-devices="photoSuggestionsTracksAndDevices"

--- a/src/components/map/HistoryControl.vue
+++ b/src/components/map/HistoryControl.vue
@@ -93,7 +93,6 @@ export default {
 
 	#history {
 		display: flex;
-		margin-right: 50px;
 		> button {
 			width: 44px;
 			height: 44px;

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -1625,6 +1625,7 @@ export default {
 				this.favorites[f.id].lat = f.lat
 				this.favorites[f.id].lng = f.lng
 				this.lastUsedFavoriteCategory = f.category
+				showSuccess(t('maps', 'Favorite {name} was saved', { name: f.name }))
 			}).catch((error) => {
 				console.error(error)
 			})
@@ -1638,6 +1639,8 @@ export default {
 					})
 				}
 				this.selectedFavorite = null
+				this.closeSidebar()
+				showError(t('maps', 'Favorite was deleted'))
 				this.$delete(this.favorites, favid)
 			}).catch((error) => {
 				console.error(error)

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -169,13 +169,6 @@
 					@redo="redoAction"
 					@slider-range-changed="sliderStart = $event.start; sliderEnd = $event.end" />
 			</div>
-			<NcActions
-				class="content-buttons"
-				:title="t('maps', 'Details')">
-				<NcActionButton
-					icon="icon-menu-sidebar"
-					@click="onMainDetailClicked" />
-			</NcActions>
 		</NcAppContent>
 		<Sidebar
 			v-if="true"


### PR DESCRIPTION
Fixes and improves the sidebar interface.

Changes
- Fixes sidebar header icon. Now uses Nextcloud icons, because the [svg api has been deprecated](https://docs.nextcloud.com/server/latest/developer_manual/html_css_design/icons.html).
- Standardizes styles and cleans up favorite form
- Automatically closes sidebar on favorite delete
- Confirmation messages for favorite form save/delete
- Removes sidebar button from top right corner of map (it appears to do nothing and only opens a blank sidebar, but I could be missing something)


## Updated Sidebar Layout

![image](https://github.com/nextcloud/maps/assets/38274055/dc4d857c-f4a2-4b92-acd5-33191e7033f6)

## Confirmation Dialogs

![image](https://github.com/nextcloud/maps/assets/38274055/09bc1d2b-84c9-4875-aea7-b362c0b548db)

![image](https://github.com/nextcloud/maps/assets/38274055/3097d6b1-188a-433c-a088-aef852b709bf)

