### PR TITLE
Replace "Settings" by "Maps settings" (consistency with other apps)

### DIFF
--- a/templates/settings/index.php
+++ b/templates/settings/index.php
@@ -1,7 +1,7 @@
 <div id="app-settings">
     <div id="app-settings-header">
         <button class="settings-button" data-apps-slide-toggle="#app-settings-content">
-            <?php p($l->t('Settings')); ?>
+            <?php p($l->t('Maps settings')); ?>
         </button>
     </div>
     <div id="app-settings-content">


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Everything is in the title ; other apps use the following pattern : "{Name of app} settings"
... so it will be consistent with other apps.