### PR TITLE
Fix tiles not working on public pages because of missing CSP entries

### DIFF
--- a/lib/Controller/PublicFavoritePageController.php
+++ b/lib/Controller/PublicFavoritePageController.php
@@ -140,6 +140,7 @@ class PublicFavoritePageController extends PublicShareController {
 			$csp = new ContentSecurityPolicy();
 			// map tiles
 			$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+			$csp->addAllowedImageDomain('https://tile.openstreetmap.org');
 			$csp->addAllowedImageDomain('https://server.arcgisonline.com');
 			$csp->addAllowedImageDomain('https://*.cartocdn.com');
 			$csp->addAllowedImageDomain('https://*.opentopomap.org');

--- a/lib/Controller/PublicPageController.php
+++ b/lib/Controller/PublicPageController.php
@@ -207,6 +207,7 @@ class PublicPageController extends AuthPublicShareController {
 			$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
 			// map tiles
 			$csp->addAllowedImageDomain('https://*.tile.openstreetmap.org');
+			$csp->addAllowedImageDomain('https://tile.openstreetmap.org');
 			$csp->addAllowedImageDomain('https://server.arcgisonline.com');
 			$csp->addAllowedImageDomain('https://*.cartocdn.com');
 			$csp->addAllowedImageDomain('https://*.opentopomap.org');


### PR DESCRIPTION
A CSP entry for https://tile.openstreetmap.org was introduced in 8e9e960ac7bf8c9e7ac638775504b007242bb3e9, but it was only added to the PageController but it should be added to all the places where the CSP headers are generated.

cc @tacruc, @Ma27 