### PR TITLE
Fix issue 1332 (photos from external folders not shown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.6.0 - 2024.12.31 Scan photos of specific directory
+## 1.6.0 - 2025.01.10 Georeferenced photos from external folders not shown on map
+### Added
 - Scan photos of specific directory [#1231](https://github.com/nextcloud/maps/pull/1231) @tetebueno
+  
+### Fixed
+- Georeferenced photos from external folders not shown on map
+  [#1371](https://github.com/nextcloud/maps/issues/1371) @umgfoin
 
 
 ## 1.5.0 - 2024.11.16 Nextcloud Hub 9

--- a/lib/Service/GeophotoService.php
+++ b/lib/Service/GeophotoService.php
@@ -28,6 +28,7 @@ use OCP\Files\Search\ISearchComparison;
 use OCP\ICacheFactory;
 use OCP\IL10N;
 use OCP\IPreview;
+use Psr\Log\LoggerInterface;
 
 class GeophotoService {
 
@@ -45,6 +46,7 @@ class GeophotoService {
 	private \OCP\ICache $backgroundJobCache;
 
 	public function __construct(
+		private LoggerInterface $logger,
 		IRootFolder $root,
 		IL10N $l10n,
 		GeophotoMapper $photoMapper,

--- a/lib/Service/GeophotoService.php
+++ b/lib/Service/GeophotoService.php
@@ -106,56 +106,53 @@ class GeophotoService {
 			$photoEntities = $this->photoMapper->findAll($userId);
 
 			$filesById = [];
-			$cache = $folder->getStorage()->getCache();
 			$previewEnableMimetypes = $this->getPreviewEnabledMimetypes();
 			foreach ($photoEntities as $photoEntity) {
-				$cacheEntry = $cache->get($photoEntity->getFileId());
-				if ($cacheEntry) {
-					// this path is relative to owner's storage
-					//$path = $cacheEntry->getPath();
-					//but we want it relative to current user's storage
-					$files = $folder->getById($photoEntity->getFileId());
-					if (empty($files)) {
-						continue;
+				// this path is relative to owner's storage
+				//$path = $cacheEntry->getPath();
+				//but we want it relative to current user's storage
+				$files = $folder->getById($photoEntity->getFileId());
+				if (empty($files)) {
+					continue;
+				}
+				$file = array_shift($files);
+	
+				if ($file === null) {
+					continue;
+				}
+				$path = $userFolder->getRelativePath($file->getPath());
+				$isIgnored = false;
+				foreach ($ignoredPaths as $ignoredPath) {
+					if (str_starts_with($path, $ignoredPath)) {
+						$isIgnored = true;
+						break;
 					}
-					$file = array_shift($files);
-					if ($file === null) {
-						continue;
-					}
-					$path = $userFolder->getRelativePath($file->getPath());
-					$isIgnored = false;
-					foreach ($ignoredPaths as $ignoredPath) {
-						if (str_starts_with($path, $ignoredPath)) {
-							$isIgnored = true;
-							break;
-						}
-					}
-					if (!$isIgnored) {
-						$isRoot = $file === $userFolder;
+				}
+				if (!$isIgnored) {
+					$isRoot = $file === $userFolder;
 
-						$file_object = new \stdClass();
-						$file_object->fileId = $photoEntity->getFileId();
-						$file_object->fileid = $file_object->fileId;
-						$file_object->lat = $photoEntity->getLat();
-						$file_object->lng = $photoEntity->getLng();
-						$file_object->dateTaken = $photoEntity->getDateTaken() ?? \time();
-						$file_object->basename = $isRoot ? '' : $file->getName();
-						$file_object->filename = $this->normalizePath($path);
-						$file_object->etag = $cacheEntry->getEtag();
-						//Not working for NC21 as Viewer requires String representation of permissions
-						//                $file_object->permissions = $file->getPermissions();
-						$file_object->type = $file->getType();
-						$file_object->mime = $file->getMimetype();
-						$file_object->lastmod = $file->getMTime();
-						$file_object->size = $file->getSize();
-						$file_object->path = $path;
-						$file_object->isReadable = $file->isReadable();
-						$file_object->isUpdateable = $file->isUpdateable();
-						$file_object->isShareable = $file->isShareable();
-						$file_object->isDeletable = $file->isDeletable();
-						$file_object->hasPreview = in_array($cacheEntry->getMimeType(), $previewEnableMimetypes);
-						$filesById[] = $file_object;
-					}
+					$file_object = new \stdClass();
+					$file_object->fileId = $photoEntity->getFileId();
+					$file_object->fileid = $file_object->fileId;
+					$file_object->lat = $photoEntity->getLat();
+					$file_object->lng = $photoEntity->getLng();
+					$file_object->dateTaken = $photoEntity->getDateTaken() ?? \time();
+					$file_object->basename = $isRoot ? '' : $file->getName();
+					$file_object->filename = $this->normalizePath($path);
+					$file_object->etag = $file->getEtag();
+					//Not working for NC21 as Viewer requires String representation of permissions
+					//                $file_object->permissions = $file->getPermissions();
+					$file_object->type = $file->getType();
+					$file_object->mime = $file->getMimetype();
+					$file_object->lastmod = $file->getMTime();
+					$file_object->size = $file->getSize();
+					$file_object->path = $path;
+					$file_object->isReadable = $file->isReadable();
+					$file_object->isUpdateable = $file->isUpdateable();
+					$file_object->isShareable = $file->isShareable();
+					$file_object->isDeletable = $file->isDeletable();
+					$file_object->hasPreview = in_array($file_object->mime, $previewEnableMimetypes);
+					$filesById[] = $file_object;
 				}
 			}
 			$this->photosCache->set($key, $filesById, 60 * 60 * 24);
@@ -199,65 +196,61 @@ class GeophotoService {
 			$tz = new \DateTimeZone(\date_default_timezone_get());
 		}
 		foreach ($photoEntities as $photoEntity) {
-			$cacheEntry = $cache->get($photoEntity->getFileId());
-			if ($cacheEntry) {
-				// this path is relative to owner's storage
-				//$path = $cacheEntry->getPath();
-				// but we want it relative to current user's storage
-				$files = $folder->getById($photoEntity->getFileId());
-				if (empty($files)) {
-					continue;
+			// this path is relative to owner's storage
+			//$path = $cacheEntry->getPath();
+			// but we want it relative to current user's storage
+			$files = $folder->getById($photoEntity->getFileId());
+			if (empty($files)) {
+				continue;
+			}
+			$file = array_shift($files);
+			if ($file === null) {
+				continue;
+			}
+			$path = $userFolder->getRelativePath($file->getPath());
+			$isIgnored = false;
+			foreach ($ignoredPaths as $ignoredPath) {
+				if (str_starts_with($path, $ignoredPath)) {
+					$isIgnored = true;
+					break;
 				}
-				$file = array_shift($files);
-				if ($file === null) {
-					continue;
-				}
-				$path = $userFolder->getRelativePath($file->getPath());
-				$isIgnored = false;
-				foreach ($ignoredPaths as $ignoredPath) {
-					if (str_starts_with($path, $ignoredPath)) {
-						$isIgnored = true;
-						break;
-					}
-				}
-				if (!$isIgnored) {
-					$isRoot = $file === $userFolder;
+			}
+			if (!$isIgnored) {
+				$isRoot = $file === $userFolder;
 
-					//Unfortunately Exif stores the local and not the UTC time. There is no way to get the timezone, therefore it has to be given by the user.
-					$date = $photoEntity->getDateTaken() ?? \time();
+				//Unfortunately Exif stores the local and not the UTC time. There is no way to get the timezone, therefore it has to be given by the user.
+				$date = $photoEntity->getDateTaken() ?? \time();
 
-					$dateWithTimezone = new \DateTime(gmdate('Y-m-d H:i:s', $date), $tz);
-					$locations = $this->getLocationGuesses($dateWithTimezone->getTimestamp());
-					foreach ($locations as $key => $location) {
-						$file_object = new \stdClass();
-						$file_object->fileId = $photoEntity->getFileId();
-						$file_object->fileid = $file_object->fileId;
-						$file_object->path = $this->normalizePath($path);
-						$file_object->hasPreview = in_array($cacheEntry->getMimeType(), $previewEnableMimetypes);
-						$file_object->lat = $location[0];
-						$file_object->lng = $location[1];
-						$file_object->dateTaken = $date;
-						$file_object->basename = $isRoot ? '' : $file->getName();
-						$file_object->filename = $this->normalizePath($path);
-						$file_object->etag = $cacheEntry->getEtag();
-						//Not working for NC21 as Viewer requires String representation of permissions
-						//                $file_object->permissions = $file->getPermissions();
-						$file_object->type = $file->getType();
-						$file_object->mime = $file->getMimetype();
-						$file_object->lastmod = $file->getMTime();
-						$file_object->size = $file->getSize();
-						$file_object->path = $path;
-						$file_object->isReadable = $file->isReadable();
-						$file_object->isUpdateable = $file->isUpdateable();
-						$file_object->isShareable = $file->isShareable();
-						$file_object->isDeletable = $file->isDeletable();
-						$file_object->hasPreview = in_array($cacheEntry->getMimeType(), $previewEnableMimetypes);
-						$file_object->trackOrDeviceId = $key;
-						if (!array_key_exists($key, $suggestionsBySource)) {
-							$suggestionsBySource[$key] = [];
-						}
-						$suggestionsBySource[$key][] = $file_object;
+				$dateWithTimezone = new \DateTime(gmdate('Y-m-d H:i:s', $date), $tz);
+				$locations = $this->getLocationGuesses($dateWithTimezone->getTimestamp());
+				foreach ($locations as $key => $location) {
+					$file_object = new \stdClass();
+					$file_object->fileId = $photoEntity->getFileId();
+					$file_object->fileid = $file_object->fileId;
+					$file_object->path = $this->normalizePath($path);
+					$file_object->mime = $file->getMimetype();
+					$file_object->hasPreview = in_array($file_object->mime, $previewEnableMimetypes);
+					$file_object->lat = $location[0];
+					$file_object->lng = $location[1];
+					$file_object->dateTaken = $date;
+					$file_object->basename = $isRoot ? '' : $file->getName();
+					$file_object->filename = $this->normalizePath($path);
+					$file_object->etag = $file->getEtag();
+					//Not working for NC21 as Viewer requires String representation of permissions
+					//                $file_object->permissions = $file->getPermissions();
+					$file_object->type = $file->getType();
+					$file_object->lastmod = $file->getMTime();
+					$file_object->size = $file->getSize();
+					$file_object->path = $path;
+					$file_object->isReadable = $file->isReadable();
+					$file_object->isUpdateable = $file->isUpdateable();
+					$file_object->isShareable = $file->isShareable();
+					$file_object->isDeletable = $file->isDeletable();
+					$file_object->trackOrDeviceId = $key;
+					if (!array_key_exists($key, $suggestionsBySource)) {
+						$suggestionsBySource[$key] = [];
 					}
+					$suggestionsBySource[$key][] = $file_object;
 				}
 			}
 		}

--- a/lib/Service/GeophotoService.php
+++ b/lib/Service/GeophotoService.php
@@ -352,6 +352,7 @@ class GeophotoService {
 	 */
 	private function getTracksFromGPX($content): array {
 		$tracks = [];
+		libxml_use_internal_errors(false);
 		$gpx = simplexml_load_string($content);
 		foreach ($gpx->trk as $trk) {
 			$tracks[] = $trk;


### PR DESCRIPTION
[GeophotoService::getAll ](https://github.com/nextcloud/maps/blob/24f6a286f59ad04bf1a6b962226731e0c67a1f72/lib/Service/GeophotoService.php#L109)tries to load filecache-entries by id for each photo-entity in the photomapper.
Since NC30 this regularly fails for images located on ext. storage: As a result, the corresponding photos won't get included in the distributed photosCache and thus don't show up on the map.
I yet don't see the root-cause for the cache-failures here, but imho, access to the filecache is not needed - neither does it provide any performance gain. I decided to remove the corresponding filecache-code and retrieve the required attributes (Etag and mimetype) from the anyway fetched file-object.

 ```
$filesById = [];
$cache = $folder->getStorage()->getCache();
$previewEnableMimetypes = $this->getPreviewEnabledMimetypes();
foreach ($photoEntities as $photoEntity) {
         $cacheEntry = $cache->get($photoEntity->getFileId());
         if ($cacheEntry) {
                 [...]
                 $filesById[] = $file_object;
         }
         $this->photosCache->set($key, $filesById, 60 * 60 * 24);
```
This fixes #1332 

Other changes:
- injection of LoggerInterface into GeophotoService.
~~- A false failure-message when clearing the photo-cache was fixed.~~