### PR TITLE
Fix wrong failure-msg when clearing photo-cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.6.0 - 2025.01.10 Georeferenced photos from external folders not shown on map
+## 1.6.0 - [unreleased]
 ### Added
 - Scan photos of specific directory [#1231](https://github.com/nextcloud/maps/pull/1231) @tetebueno
   
 ### Fixed
 - Georeferenced photos from external folders not shown on map
   [#1371](https://github.com/nextcloud/maps/issues/1371) @umgfoin
+- Fix wrong failure-msg. when clearing photo-cache
+  [#1375](https://github.com/nextcloud/maps/pull/1375) @umgfoin
 
 
 ## 1.5.0 - 2024.11.16 Nextcloud Hub 9

--- a/lib/Service/GeophotoService.php
+++ b/lib/Service/GeophotoService.php
@@ -74,11 +74,16 @@ class GeophotoService {
 	 * @return bool
 	 */
 	public function clearCache(string $userId = ''): bool {
-		$a = $this->photosCache->clear($userId);
-		$b = $this->timeOrderedPointSetsCache->clear($userId);
-		$c = $this->backgroundJobCache->clear('recentlyAdded:'.$userId);
-		$d = $this->backgroundJobCache->clear('recentlyUpdated:'.$userId);
-		return $a and $b and $c and $d;
+		try {
+			$this->photosCache->clear($userId);
+			$this->timeOrderedPointSetsCache->clear($userId);
+			$this->backgroundJobCache->clear('recentlyAdded:'.$userId);
+			$this->backgroundJobCache->clear('recentlyUpdated:'.$userId);
+			return true;
+
+		} catch (\Exception $e) {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
`bool GeophotoService::clearCache` returns `false`, if any of the cleared caches was already empty. 
Accordingly, a failure-msg is shown in the maps-GUI. 
This change makes the function always return `true `unless an exception occurred - then `false `is returned.