### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,5 +20,3 @@ require_once __DIR__ . '/../../../lib/base.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
 Server::get(IAppManager::class)->loadApp('maps');
-
-OC_Hook::clear();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Nextcloud - maps
  *
@@ -10,11 +12,13 @@
  * @copyright Julien Veyssier 2019
  */
 
+use OCP\App\IAppManager;
+use OCP\Server;
+
 require_once __DIR__ . '/../../../tests/bootstrap.php';
 require_once __DIR__ . '/../../../lib/base.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-\OC_App::loadApp('maps');
+Server::get(IAppManager::class)->loadApp('maps');
 
 OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.

I did not add a direct reference to `tests/autoload.php` for this app because `tests/bootstrap.php` is required which requires it indirectly.