### PR TITLE
Fix incorrect closure declaration for geo-photos rescan-command.

### DIFF
--- a/lib/Command/RescanPhotos.php
+++ b/lib/Command/RescanPhotos.php
@@ -86,7 +86,7 @@ class RescanPhotos extends Command {
 			echo "Extracting coordinates from photo is performed in a BackgroundJob \n";
 		}
 		if ($userId === null) {
-			$this->userManager->callForSeenUsers(function (IUser $user, string $pathToScan) use ($inBackground) {
+			$this->userManager->callForSeenUsers(function (IUser $user, ?string $pathToScan = null) use ($inBackground) {
 				$this->rescanUserPhotos($user->getUID(), $inBackground, $pathToScan);
 			});
 		} else {


### PR DESCRIPTION
This PR fixes a newly introduced problem ([cs:fix commit d0a512](https://github.com/nextcloud/maps/commit/d0a51523199f2da4d14afadffeb9d43d351e1142)) with `occ maps scan-photos`.