### PR TITLE
Fix broken filehooks for adding/ deleting/ updating geophotos and tracks

### DIFF
--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -96,14 +96,16 @@ class PhotofilesService {
 	// add the file for its owner and users that have access
 	// check if it's already in DB before adding
 	public function addByFile(Node $file) {
-		$ownerId = $file->getOwner()->getUID();
 		if ($this->isPhoto($file)) {
+			$ownerId = $file->getOwner()->getUID();
 			$this->addPhoto($file, $ownerId);
 			// is the file accessible to other users ?
 			$accesses = $this->shareManager->getAccessList($file);
-			foreach ($accesses['users'] as $uid) {
-				if ($uid !== $ownerId) {
-					$this->addPhoto($file, $uid);
+			if (array_key_exists('users', $accesses)) {
+				foreach ($accesses['users'] as $uid) {
+					if ($uid !== $ownerId) {
+						$this->addPhoto($file, $uid);
+					}
 				}
 			}
 			return true;


### PR DESCRIPTION
1) Rewrite `isUserNode `to accept files from other storages than IHomeStorage e.g. include photos and tracks from external_files or shares. 
https://github.com/nextcloud/maps/blob/289ed6aaefae03099119d7842f54447e131ac46e/lib/Hooks/FileHooks.php#L179
This above line does not/no longer detect `IHomeStorage `derived instances. The correct form is `$node->getStorage()->instanceOfStorage("\OCP\Files\IHomeStorage")`

Anyway, this restriction is not desirable:
- it will exclude objects from external_files and shares
- unwanted nodes like `/appdata_ocxxxx/preview` will pass through

My chosen aproach:
- rejects ownerless objects and 
- considers everything starting with` /<userid>/` as an user-node worth to look at:
   Maybe this should be further restricted to `/<userid>/files`, but I currently don't see a necessity for it.
Additionally the PostWrite-hook sorts out directory-objects in early stage  as the connected functions process sgl. files only
Fixes #1394,
Fixes #1332

2) Fix possible assert in `addByFile(Node $file)` if `getAccessList($file)` returns empty result.