### PR TITLE
Update nominatim search url (deprecation)

### DIFF
--- a/lib/Service/AddressService.php
+++ b/lib/Service/AddressService.php
@@ -190,7 +190,7 @@ class AddressService {
 			$query_adr = implode(', ', $splitted_adr);
 
 			$result_json = @file_get_contents(
-				'https://nominatim.openstreetmap.org/search.php?q=' . urlencode($query_adr) . '&format=jsonv2',
+				'https://nominatim.openstreetmap.org/search?q=' . urlencode($query_adr) . '&format=jsonv2',
 				false,
 				$context
 			);


### PR DESCRIPTION
change /search.php to /search according to https://nominatim.org/release-docs/latest/api/Search/

This also fixes an issue I currently encounter where the /search.php returns HTTP 418 by nominatim while the /search doesn't.