### PR TITLE
fix(csp): protomaps sources

### DIFF
--- a/lib/Controller/AddCspTrait.php
+++ b/lib/Controller/AddCspTrait.php
@@ -47,6 +47,10 @@ trait AddCspTrait {
 					$cleanUrl .= ':' . $port;
 				}
 				$csp->addAllowedConnectDomain($cleanUrl);
+
+				if ($host === 'api.protomaps.com') {
+					$csp->addAllowedConnectDomain('https://protomaps.github.io');
+				}
 			}
 		}
 


### PR DESCRIPTION
add protomaps github pages url to CSP `connect-src` when using protomaps api for maplibre.
protomaps hosts glyphs and sprite on their github pages.

`https://api.protomaps.com/styles/v5/light/en.json?key=MY_KEY`

```json
{
  "version": 8,
  "name": "style@5.0.0 flavor@light lang@en",
  "glyphs": "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
  "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/light",
  "sources": {
    "protomaps": {
      "attribution": "<a href=\"https://github.com/protomaps/basemaps\">Protomaps</a> © <a href=\"https://openstreetmap.org\">OpenStreetMap</a>",
      "type": "vector",
      "tiles": [
        "https://api.protomaps.com/tiles/v4/{z}/{x}/{y}.mvt?key=MY_KEY"
      ],
      "maxzoom": 15
    }
  }
}
```