### PR TITLE
fix: use filepicker API for placing photos on the map

### DIFF
--- a/lib/Service/PhotofilesService.php
+++ b/lib/Service/PhotofilesService.php
@@ -291,7 +291,11 @@ class PhotofilesService {
 				if ($this->isPhoto($file) && $file->isUpdateable()) {
 					$lat = (count($lats) > $i) ? $lats[$i] : $lats[0];
 					$lng = (count($lngs) > $i) ? $lngs[$i] : $lngs[0];
-					$photo = $this->photoMapper->findByFileIdUserId($file->getId(), $userId);
+					try {
+						$photo = $this->photoMapper->findByFileIdUserId($file->getId(), $userId);
+					} catch (DoesNotExistException) {
+						$photo = null;
+					}
 					$done[] = [
 						'path' => preg_replace('/^files/', '', $file->getInternalPath()),
 						'lat' => $lat,

--- a/src/network.js
+++ b/src/network.js
@@ -1,9 +1,6 @@
 import axios from '@nextcloud/axios'
 import { default as realAxios } from 'axios'
 import { generateUrl } from '@nextcloud/router'
-import {
-	showError,
-} from '@nextcloud/dialogs'
 
 export function saveOptionValues(optionValues, myMapId = null, token = null) {
 	const req = {
@@ -328,6 +325,13 @@ export async function getPhotoSuggestions(myMapId = null, token = null, timezone
 	return axios.get(url, conf)
 }
 
+/**
+ * @param {string[]} paths
+ * @param {number[]} lats
+ * @param {number[]} lngs
+ * @param {boolean} directory - Is the placed path a directory
+ * @param {number | null} myMapId - The myMapId
+ */
 export function placePhotos(paths, lats, lngs, directory = false, myMapId = null) {
 	const req = {
 		paths,

--- a/src/utils/photoPicker.ts
+++ b/src/utils/photoPicker.ts
@@ -1,0 +1,109 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { DialogBuilder, FilePickerBuilder } from '@nextcloud/dialogs'
+import { n, t } from '@nextcloud/l10n'
+import { placePhotos } from '../network.js'
+
+interface LotLong {
+	lat: number
+	lng: number
+}
+
+const dialogBuilder = new DialogBuilder(t('maps', 'What do you want to place'))
+
+/**
+ * Place photos or a photo folder on a given map and location.
+ *
+ * @param latLong - The geo location where to place the photos
+ * @param myMapId - The map to place the photos
+ */
+export async function placeFileOrFolder(latLong: LotLong, myMapId: number) {
+	const { promise, resolve } = Promise.withResolvers<unknown>()
+	const dialog = dialogBuilder
+		.setButtons([
+			{
+				label: t('maps', 'Photo folder'),
+				callback() {
+					resolve(placeFolder(latLong, myMapId))
+				},
+			},
+			{
+				label: t('maps', 'Photo files'),
+				callback() {
+					resolve(placeFiles(latLong, myMapId))
+				},
+				variant: 'primary',
+			},
+		])
+		.build()
+
+	await dialog.show()
+	return promise
+}
+
+/**
+ * Callback to select and place a folder.
+ *
+ * @param latLong - The location where to place
+ * @param myMapId - The map to place photos to
+ */
+async function placeFolder(latLong: LotLong, myMapId: number) {
+	const filePickerBuilder = new FilePickerBuilder(t('maps', 'Choose directory of photos to place'))
+	const filePicker = filePickerBuilder.allowDirectories(true)
+		.setMimeTypeFilter(['httpd/unix-directory'])
+		.setButtonFactory((nodes) => [{
+			callback: () => {},
+			label: nodes.length === 1
+				? t('maps', 'Select {photo}', { photo: nodes[0].displayname }, { escape: false })
+				: (nodes.length === 0
+					? t('maps', 'Select folder')
+					: n('maps', 'Select %n folder', 'Select %n folders', nodes.length)
+				),
+			disabled: nodes.length === 0,
+			variant: 'primary',
+		}])
+		.setMultiSelect(false)
+		.build()
+
+	try {
+		const folder = await filePicker.pick()
+		return placePhotos([folder], [latLong.lat], [latLong.lng], true, myMapId)
+	} catch {
+		// cancelled picking
+	}
+}
+
+/**
+ * Callback to select and place on or multiple photo files.
+ *
+ * @param latLong - The location where to place
+ * @param myMapId - The map to place photos to
+ */
+async function placeFiles(latLong: LotLong, myMapId: number) {
+	const filePickerBuilder = new FilePickerBuilder(t('maps', 'Choose photos to place'))
+	const filePicker = filePickerBuilder
+		.setMimeTypeFilter(['image/jpeg', 'image/tiff'])
+		.setButtonFactory((nodes) => [{
+			callback: () => {},
+			label: nodes.length === 1
+				? t('maps', 'Select {photo}', { photo: nodes[0].displayname }, { escape: false })
+				: (nodes.length === 0
+					? t('maps', 'Select photo')
+					: n('maps', 'Select %n photo', 'Select %n photos', nodes.length)
+				),
+			disabled: nodes.length === 0,
+			variant: 'primary',
+		}])
+		.setMultiSelect(true)
+		.build()
+
+	try {
+		const nodes = await filePicker.pick()
+		return placePhotos(nodes, [latLong.lat], [latLong.lng], false, myMapId)
+	} catch {
+		// cancelled picking
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
 	"extends": "@vue/tsconfig",
 	"compilerOptions": {
+		"allowJs": true,
 		"allowImportingTsExtensions": true,
 		"rewriteRelativeImportExtensions": true,
 		"noEmit": false,
+		"outDir": "js",
 	},
 	"vueCompilerOptions": {
 		"target": 2.7


### PR DESCRIPTION
- [x] :warning:  based on #1462 


With Nextcloud 28 the `OC.dialogs` API was deprecated, instead we need to use `@nextcloud/dialogs` for the filepicker. So this fixes:
1. The deprecated `OC.dialogs` usage
2. Bug where both dialogs where opened at the same time (file and folder picker).
3. Properly place photos on other than the default map