### PR TITLE
Update to Nextcloud 32 deprecation removals

### DIFF
--- a/lib/Hooks/FileHooks.php
+++ b/lib/Hooks/FileHooks.php
@@ -18,7 +18,7 @@ use OCA\Maps\Service\TracksService;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\Lock\ILockingProvider;
-use OCP\Share;
+use OCP\Share\IShare;
 use OCP\Util;
 use function OCP\Log\logger;
 
@@ -139,7 +139,7 @@ class FileHooks {
 
 	public function postUnShare($params) {
 		//logger('maps')->debug("Hook postUnShare");
-		if ($params['shareType'] === Share::SHARE_TYPE_USER) {
+		if ($params['shareType'] === IShare::TYPE_USER) {
 			if ($params['itemType'] === 'file') {
 				$targetUserId = $params['shareWith'];
 				$fileId = $params['fileSource']; // or itemSource
@@ -151,7 +151,7 @@ class FileHooks {
 
 	public function preUnShare($params) {
 		//logger('maps')->debug("Hook preUnShare");
-		if ($params['shareType'] === Share::SHARE_TYPE_USER) {
+		if ($params['shareType'] === IShare::TYPE_USER) {
 			if ($params['itemType'] === 'folder') {
 				$targetUserId = $params['shareWith'];
 				$dirId = $params['fileSource']; // or itemSource

--- a/tests/stubs/oc_share_constants.php
+++ b/tests/stubs/oc_share_constants.php
@@ -10,60 +10,16 @@ namespace OC\Share;
 use OCP\Share\IShare;
 
 class Constants {
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_USER instead
-	 */
-	public const SHARE_TYPE_USER = 0;
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_GROUP instead
-	 */
-	public const SHARE_TYPE_GROUP = 1;
-	// const SHARE_TYPE_USERGROUP = 2; // Internal type used by DefaultShareProvider
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_LINK instead
-	 */
-	public const SHARE_TYPE_LINK = 3;
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_EMAIL instead
-	 */
-	public const SHARE_TYPE_EMAIL = 4;
-	public const SHARE_TYPE_CONTACT = 5; // ToDo Check if it is still in use otherwise remove it
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_REMOTE instead
-	 */
-	public const SHARE_TYPE_REMOTE = 6;
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_CIRCLE instead
-	 */
-	public const SHARE_TYPE_CIRCLE = 7;
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_GUEST instead
-	 */
-	public const SHARE_TYPE_GUEST = 8;
-	/**
-	 * @deprecated 17.0.0 - use IShare::REMOTE_GROUP instead
-	 */
-	public const SHARE_TYPE_REMOTE_GROUP = 9;
-	/**
-	 * @deprecated 17.0.0 - use IShare::TYPE_ROOM instead
-	 */
-	public const SHARE_TYPE_ROOM = 10;
-	// const SHARE_TYPE_USERROOM = 11; // Internal type used by RoomShareProvider
-	/**
-	 * @deprecated 21.0.0 - use IShare::TYPE_DECK instead
-	 */
-	public const SHARE_TYPE_DECK = 12;
-	// const SHARE_TYPE_DECK_USER = 13; // Internal type used by DeckShareProvider
-
-	// Note to developers: Do not add new share types here
-
 	public const FORMAT_NONE = -1;
 	public const FORMAT_STATUSES = -2;
 	public const FORMAT_SOURCES = -3;  // ToDo Check if it is still in use otherwise remove it
 
 	public const RESPONSE_FORMAT = 'json'; // default response format for ocs calls
 
-	public const TOKEN_LENGTH = 15; // old (oc7) length is 32, keep token length in db at least that for compatibility
+	public const MIN_TOKEN_LENGTH = 6; // 19,770,609,664 different possible variations
+	public const DEFAULT_TOKEN_LENGTH = 15; // 54,960,434,128,018,667,122,720,768 different possible variations
+	public const MAX_TOKEN_LENGTH = 32; // 8,167,835,760,036,914,488,254,418,108,462,708,901,695,678,621,570,564,096 different possible variations
+	public const TOKEN_LENGTH = self::DEFAULT_TOKEN_LENGTH; // old (oc7) length is 32, keep token length in db at least that for compatibility
 
 	protected static $shareTypeUserAndGroups = -1;
 	protected static $shareTypeGroupUserUnique = 2;


### PR DESCRIPTION
\OC\Share::SHARE_TYPE_USER is deprecated since Nextcloud 17.

Closes: #1469