### PR TITLE
fix: pass RichObjectParameter properties as strings

### DIFF
--- a/src/components/map/ClickSearchPopup.vue
+++ b/src/components/map/ClickSearchPopup.vue
@@ -116,8 +116,8 @@ export default {
 			const object = {
 				id: 'geo:' + this.latLng.lat + ',' + this.latLng.lng,
 				name: this.formattedAddress,
-				latitude: this.latLng.lat,
-				longitude: this.latLng.lng,
+				latitude: this.latLng.lat.toString(),
+				longitude: this.latLng.lng.toString(),
 			}
 			action.callback(object)
 		},


### PR DESCRIPTION
Follow-up to 8e3ae0269e779650a9f07f7bc26e6b97a614518f, but for popup menu
 - Valid since Nextcloud 22, maybe was blocked a bit later

Fix for this button:
  <img width="296" height="280" alt="image" src="https://github.com/user-attachments/assets/0c36038d-c07a-4991-aa67-acbec4d9180f" />
