### PR TITLE
Redirect user to login page when opening maps while logged out

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -32,7 +32,7 @@ class PageController extends Controller {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private string $userId,
+		private ?string $userId,
 		private IEventDispatcher $eventDispatcher,
 		IAppConfig $appConfig,
 		private IInitialState $initialState,


### PR DESCRIPTION
Fix for issue https://github.com/nextcloud/maps/issues/1628

Has been tested on Nextcloud 33.0.6, this simple one-line change will actually redirect to the login page when opening maps while not logged in.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
