### PR TITLE
fix: eliminate 404 error when clicking on the map

### DIFF
--- a/src/components/map/ClickSearchPopup.vue
+++ b/src/components/map/ClickSearchPopup.vue
@@ -61,8 +61,10 @@ export default {
 			address: null,
 			formattedAddress: '',
 			mapActions: window.OCA && window.OCA.Maps ? window.OCA.Maps.mapActions : [],
-			icon: L.icon({
-				iconUrl: 'noIcon',
+			icon: L.divIcon({
+				className: '',
+				html: '',
+				iconSize: [0, 0],
 			}),
 		}
 	},


### PR DESCRIPTION
The ClickSearchPopup marker icon was created with L.icon({ iconUrl: 'noIcon' }), a relative URL that resolved to /apps/maps/noIcon which does not exist on the server.

Replace with L.divIcon producing a zero-size invisible element. The marker only serves as an anchor for the popup and does not need a visual icon, so a div element with no dimensions is sufficient.