### PR TITLE
fix: allow map popup to reopen after being closed

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -370,7 +370,6 @@ export default {
 
 			const thereWasAPopup = this.map.contextmenu._visible
 				|| this.placingContact
-				|| (this.map._popup !== undefined && this.map._popup !== null)
 				|| this.leftClickSearching
 
 			const hadSpider = this.$refs.favoritesLayer?.spiderfied


### PR DESCRIPTION
Clicking on the map only opened the popup on the very first click. Subsequent clicks were silently ignored.

The onMapNormalLeftClick handler used Leaflet's internal map._popup property to detect whether a popup was currently open. After the ClickSearchPopup marker was removed from the map, this reference could persist as stale and non-null, causing every following click to believe a popup was still active.

The leftClickSearching flag already tracks whether our popup is open, making the map._popup check redundant. Removing it restores the expected open/close toggle behavior.