### PR TITLE
fix: remove favorite marker from map immediately after deletion

### DIFF
--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -1615,7 +1615,7 @@ export default {
 				this.selectedFavorite = null
 				this.closeSidebar()
 				showError(t('maps', 'Favorite was deleted'))
-				this.$delete(this.favorites, favid)
+				delete this.favorites[favid]
 			}).catch((error) => {
 				console.error(error)
 			})
@@ -1632,7 +1632,7 @@ export default {
 					})
 				}
 				favids.forEach((favid) => {
-					this.$delete(this.favorites, favid)
+					delete this.favorites[favid]
 				})
 			}).catch((error) => {
 				console.error(error)
@@ -1724,7 +1724,7 @@ export default {
 					return this.favorites[favid].category === catid
 				})
 				favIds.forEach((favid) => {
-					this.$delete(this.favorites, favid)
+					delete this.favorites[favid]
 				})
 				showSuccess(t('maps', 'Favorite category {favoriteName} unlinked from map', { favoriteName: catid ?? '' }))
 			}).catch((error) => {


### PR DESCRIPTION
Replace `this.$delete()` with native `delete` in all favorite deletion paths (single delete, bulk delete, category unlink).

`this.$delete()` is a Vue 2 compatibility shim that may not reliably trigger Vue 3's Proxy-based reactivity system when removing keys from a reactive object. This caused the FavoritesLayer deep watcher on displayedFavorites to not fire, leaving stale markers on the map until a full reload.

In Vue 3, the native `delete` operator is intercepted by the Proxy's deleteProperty trap, which properly triggers reactivity.

Affected methods:
- onFavoriteDelete (single favorite via sidebar/popup)
- onFavoritesDelete (bulk delete via cluster right-click)
- onDeleteFavoriteCategoryFromMap (unlink shared category)