### PR TITLE
fix: prevent popup from reopening after adding favorite from map click

### DIFF
--- a/src/components/map/ClickSearchPopup.vue
+++ b/src/components/map/ClickSearchPopup.vue
@@ -8,7 +8,7 @@
 		<textarea v-else
 			id="clickSearchAddress"
 			v-model="formattedAddress" />
-		<button v-if="favoriteIsCreatable" class="search-add-favorite" @click="onAddFavorite">
+		<button v-if="favoriteIsCreatable" class="search-add-favorite" @click.stop="onAddFavorite">
 			<span class="icon-favorite" />
 			{{ t('maps', 'Add to favorites') }}
 		</button>


### PR DESCRIPTION
Add @click.stop modifier to the 'Add to favorites' button click handler in ClickSearchPopup to call event.stopPropagation(). Without it, the click event bubbles up through the Leaflet popup overlay to the map container, triggering onMapClick and opening a duplicate popup.